### PR TITLE
v3.3.119: 配置/日志系统重构、数据库迁移、GMLock 跨页锁与下载队列增强

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "js/ts.tsdk.path": "node_modules\\typescript\\lib"
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iwaradownloadtool",
-  "version": "3.3.118",
+  "version": "3.3.119",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iwaradownloadtool",
-      "version": "3.3.118",
+      "version": "3.3.119",
       "dependencies": {
         "dayjs": "^1.11.20",
         "idb": "^8.0.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@types/tampermonkey": "^5.0.5",
         "esbuild": "^0.28.1",
         "tsx": "^4.22.3",
-        "typescript": "^6.0.3"
+        "typescript": "^7.0.2"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -478,6 +478,346 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
     "node_modules/dayjs": {
       "version": "1.11.21",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
@@ -567,17 +907,38 @@
       }
     },
     "node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
+        "tsc": "bin/tsc"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "iwaradownloadtool",
   "displayName": "IwaraDownloadTool",
-  "version": "3.3.118",
+  "version": "3.3.119",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
     "@types/tampermonkey": "^5.0.5",
     "esbuild": "^0.28.1",
     "tsx": "^4.22.3",
-    "typescript": "^6.0.3"
+    "typescript": "^7.0.2"
   }
 }

--- a/src/core/class.ts
+++ b/src/core/class.ts
@@ -1,11 +1,66 @@
 import "./env";
-import { isNullOrUndefined, isVideoInfo, prune, UUID } from "./env";
+import { hasFunction, isNullOrUndefined, isVideoInfo, prune, stringify, UUID } from "./env";
 import { VersionState } from "./enum";
 import { originalAddEventListener, originalRemoveEventListener } from "./hijack";
+
+/** 变量占位符分隔符（与 String.prototype.replaceVariable 默认前缀/后缀一致） */
+const VARIABLE_PREFIX = '%#';
+const VARIABLE_SUFFIX = '#%';
+
+/** 将字符串转义为正则安全形式（参考 replaceVariable 内部实现） */
+function escapeRegex(str: string): string {
+    return str.replace(/[\.\*\+\?\^\$\{\}\(\)\|\[\]\\]/g, '\\$&');
+}
+
+/**
+ * 路径段中的原子组成部分
+ * - literal: 字面文本
+ * - variable: 变量引用，形如 %#name#% 或 %#name:format#%
+ */
+type PathPart =
+    | { kind: 'literal'; value: string }
+    | { kind: 'variable'; name: string; format: string | null };
+
+/**
+ * 词法单元
+ * - sep: 路径分隔符（\ 或 /，记录原始字符以辅助类型判定）
+ * - text: 分隔符之间的非空段文本（含变量占位符，由 parseParts 进一步切分）
+ */
+type PathToken =
+    | { kind: 'sep'; char: '\\' | '/' }
+    | { kind: 'text'; value: string };
+
+/**
+ * 路径段节点
+ * - kind: 段语义（"." 为 dot，".." 为 dotdot，其余为 name）
+ * - parts: 段内的原子列表（字面文本 + 变量引用）
+ */
+interface PathSegment {
+    kind: 'name' | 'dot' | 'dotdot';
+    parts: PathPart[];
+}
+
+/**
+ * 路径语法树（AST）
+ * - type: 路径类型
+ * - root: 根节点（Windows 盘符 "C:" / Unix 根 "/"，相对路径为 null）
+ * - segments: 段节点列表（不含根，空段与尾部分隔符已剥离）
+ */
+interface PathAST {
+    type: 'Windows' | 'Unix' | 'Relative';
+    root: string | null;
+    segments: PathSegment[];
+}
+
 /**
  * 路径处理类
  * 实现LocalPath接口，提供路径解析和规范化功能
  * 支持Windows、Unix和相对路径
+ *
+ * 基于 AST 实现：构造时先把路径字符串解析为语法树（词法层把 %#变量#% 识别为独立节点），
+ * 再依次执行 语义校验 → 规范化（解析 "./.." 导航）→ 提取目录/文件名/基础名/扩展名。
+ * 变量节点在 AST 中保持为不透明节点，渲染时还原为 %#name#% / %#name:format#% 形式，
+ * 可通过 resolve() 一次性替换为实际值。
  */
 export class Path implements LocalPath {
     public readonly fullPath: string;   // 归一化后的完整路径
@@ -15,10 +70,17 @@ export class Path implements LocalPath {
     public readonly extension: string;  // 拓展名（不含点）
     public readonly baseName: string;   // 文件名（不含拓展名）
 
+    /** 解析出的路径语法树（含变量节点），可供后续解释/渲染复用 */
+    public readonly ast: PathAST;
+
+    /** 规范化后的语法树（已解析 "./.." 导航），供 resolve() 等解释器复用 */
+    private readonly normalized: PathAST;
+
     /**
-     * 构造函数
-     * @param inputPath 输入路径字符串
-     * @throws 如果路径为空或无效
+     * 构造函数：解析为 AST → 校验 → 规范化 → 提取各组成部分
+     * @param input 输入路径字符串（可含 %#变量#% / %#变量:格式#%）
+     * @param validate 是否校验路径合法性（默认 true）
+     * @throws 如果路径为空、为 UNC、非法或导航越界
      */
     constructor(input: string, validate: boolean = true) {
         // 空路径处理
@@ -27,247 +89,309 @@ export class Path implements LocalPath {
         }
 
         // 不接受UNC路径（以"\\\\"开头）
-        if (this.isUNC(input)) {
+        if (input.startsWith('\\\\')) {
             throw new Error("不接受UNC路径");
         }
 
-        // 判断路径类型（Windows绝对、Unix绝对或相对路径）
-        const detectedType = this.detectPathType(input);
+        // 词法 + 语法分析：解析为 AST
+        const ast = Path.parse(input);
+        this.type = ast.type;
+        this.ast = ast;
 
-        // 根据不同平台校验路径基本合法性
-        if (validate) this.validatePath(input, detectedType);
+        // 语义校验（基于 AST：变量名豁免非法字符，变量格式参数仍需检查）
+        if (validate) Path.validate(ast);
 
-        // 归一化路径：统一分隔符、合并重复分隔符、处理末尾斜杠，并解析导航路径
-        const normalized = this.normalizePath(input, detectedType);
+        // 语义分析：解析 "." 与 ".." 导航，得到规范化 AST
+        const normalized = Path.normalize(ast);
+        this.normalized = normalized;
 
-        // 从归一化后的路径中提取目录、文件名、基础名与拓展名
-        const directory = this.extractDirectory(normalized, detectedType);
-        const fileName = this.extractFileName(normalized, detectedType);
-        const { baseName, extension } = this.extractBaseAndExtension(fileName);
-
-        this.type = detectedType;
-        this.fullPath = normalized;
-        this.directory = directory;
-        this.fullName = fileName;
+        // 解释执行：从规范化 AST 提取各组成部分
+        this.fullPath = Path.render(normalized);
+        this.directory = Path.extractDirectory(normalized);
+        this.fullName = Path.extractFileName(normalized);
+        const { baseName, extension } = Path.extractBaseAndExtension(this.fullName);
         this.baseName = baseName;
         this.extension = extension;
     }
 
-    // 判断是否为UNC路径（以"\\\\"开头）
     /**
-     * 判断是否为UNC路径
-     * @param path 路径字符串
-     * @returns 如果是UNC路径返回true
+     * 词法分析：将路径字符串切分为词法单元流
+     * - 分隔符（\ 或 /）→ sep 单元（记录原始字符以辅助类型判定）
+     * - 分隔符之间的非空文本 → text 单元（含变量占位符，由 parseParts 进一步切分）
+     * 重复/首尾分隔符自然产生空文本并跳过，无需额外的合并与裁剪处理
+     * @param input 原始路径字符串
+     * @returns 词法单元流
      */
-    private isUNC(path: string): boolean {
-        return path.startsWith('\\\\');
+    private static tokenize(input: string): PathToken[] {
+        const tokens: PathToken[] = [];
+        let start = 0;
+        for (let i = 0; i <= input.length; i++) {
+            const ch = input[i];
+            if (ch === '\\' || ch === '/' || i === input.length) {
+                // 分隔符之间若有非空文本，产出 text 单元
+                if (i > start) {
+                    tokens.push({ kind: 'text', value: input.substring(start, i) });
+                }
+                // 分隔符本身产出 sep 单元
+                if (ch === '\\' || ch === '/') {
+                    tokens.push({ kind: 'sep', char: ch });
+                }
+                start = i + 1;
+            }
+        }
+        return tokens;
     }
 
-    // 判断路径类型：Windows绝对路径、Unix绝对路径或相对路径
     /**
-     * 检测路径类型
-     * @param path 路径字符串
-     * @returns 路径类型: Windows、Unix或Relative
+     * 语法分析：将词法单元流解析为 AST
+     * 依据单元流判定路径类型与根节点：
+     * - 首个单元为盘符文本（如 "C:"）且其后为分隔符 → Windows，根为盘符
+     * - 首个单元为 "/" 分隔符 → Unix，根为 "/"
+     * - 其余 → Relative（无根，前导分隔符视为冗余直接忽略）
+     * 文本单元转为段节点，分隔符单元直接跳过（重复/首尾分隔符自然折叠）
+     * @param input 原始路径字符串
+     * @returns 路径语法树
      */
-    private detectPathType(path: string): 'Windows' | 'Unix' | 'Relative' {
-        // Windows绝对路径：如 "C:\xxx" 或 "C:/xxx"
-        if (/^[A-Za-z]:[\\/]/.test(path)) {
-            return 'Windows';
+    private static parse(input: string): PathAST {
+        const tokens = Path.tokenize(input);
+        const first = tokens[0];
+        const second = tokens[1];
+
+        // 类型判定：盘符 + 分隔符 → Windows；"/" 开头 → Unix；否则 Relative
+        const isWindows = first.kind === 'text'
+            && /^[A-Za-z]:$/.test(first.value)
+            && second.kind === 'sep';
+        const isUnix = !isWindows && first.kind === 'sep' && first.char === '/';
+        const type = isWindows ? 'Windows' : isUnix ? 'Unix' : 'Relative';
+
+        // 根节点：Windows 为盘符、Unix 为 "/"；同时跳过根相关单元
+        let root: string | null = null;
+        let index = 0;
+        if (isWindows && first.kind === 'text') {
+            root = first.value;
+            index = 2; // 跳过盘符与其后的分隔符
+        } else if (isUnix) {
+            root = '/';
+            index = 1; // 跳过根分隔符
         }
-        // Unix绝对路径：以 "/" 开头
-        if (path.startsWith('/')) {
-            return 'Unix';
+
+        // 文本单元 → 段节点（含变量原子），分隔符单元忽略
+        const segments: PathSegment[] = [];
+        for (; index < tokens.length; index++) {
+            const token = tokens[index];
+            if (token.kind === 'sep') continue;
+            segments.push({
+                kind: token.value === '.' ? 'dot' : token.value === '..' ? 'dotdot' : 'name',
+                parts: Path.parseParts(token.value),
+            });
         }
-        // 否则视为相对路径
-        return 'Relative';
+        return { type, root, segments };
     }
 
-    // 校验路径合法性：Windows路径检查非法字符，Unix/相对路径检查空字符及非法字符（相对路径）
     /**
-     * 验证路径合法性
-     * @param path 路径字符串 
-     * @param type 路径类型
-     * @throws 如果路径包含非法字符或格式不正确
+     * 词法分析：将段文本切分为「字面 + 变量」原子列表
+     * 识别 ${VARIABLE_PREFIX}name${VARIABLE_SUFFIX} 与 ${VARIABLE_PREFIX}name:format${VARIABLE_SUFFIX} 两种变量语法
+     * @param text 段原始文本
+     * @param prefix 变量前缀（默认 %#）
+     * @param suffix 变量后缀（默认 #%）
+     * @returns 原子列表
      */
-    private validatePath(path: string, type: 'Windows' | 'Unix' | 'Relative'): void {
-        const invalidChars = /[<>:"|?*]/;
-        if (type === 'Windows') {
-            if (!/^[A-Za-z]:[\\/]/.test(path)) {
+    private static parseParts(
+        text: string,
+        prefix: string = VARIABLE_PREFIX,
+        suffix: string = VARIABLE_SUFFIX
+    ): PathPart[] {
+        const parts: PathPart[] = [];
+        let lastIndex = 0;
+        // 动态构建变量正则：前缀/后缀经转义，避免特殊字符干扰（参考 replaceVariable）
+        const varRe = new RegExp(`${escapeRegex(prefix)}(.*?)${escapeRegex(suffix)}`, 'g');
+        let match: RegExpExecArray | null;
+        while ((match = varRe.exec(text)) !== null) {
+            // 变量之前的字面文本
+            if (match.index > lastIndex) {
+                parts.push({ kind: 'literal', value: text.substring(lastIndex, match.index) });
+            }
+            // 变量内容：冒号前为变量名，冒号后为格式参数
+            const content = match[1];
+            const colon = content.indexOf(':');
+            if (colon === -1) {
+                parts.push({ kind: 'variable', name: content, format: null });
+            } else {
+                parts.push({
+                    kind: 'variable',
+                    name: content.substring(0, colon),
+                    format: content.substring(colon + 1),
+                });
+            }
+            lastIndex = varRe.lastIndex;
+        }
+        // 变量之后的字面文本
+        if (lastIndex < text.length) {
+            parts.push({ kind: 'literal', value: text.substring(lastIndex) });
+        }
+        return parts;
+    }
+
+    /**
+     * 语义校验（基于 AST）
+     * 变量节点视为不透明：变量名豁免非法字符检查，变量格式参数仍需检查
+     * @param ast 路径语法树
+     * @throws 如果路径非法
+     */
+    private static validate(ast: PathAST): void {
+        if (ast.type === 'Windows') {
+            if (!ast.root || !/^[A-Za-z]:$/.test(ast.root)) {
                 throw new Error("无效的Windows路径格式");
             }
-            const segments = path.split(/[\\/]/);
-            // 驱动器部分不检测，从第二段开始
-            for (let i = 1; i < segments.length; i++) {
-                let segment = segments[i];
-                let variables = [...segment.matchAll(/%#(.*?)#%/g)].map(match => {
-                    let variable = match[1].split(':')
-                    if (variable.length > 1) {
-                        if (invalidChars.test(variable[1])) {
-                            throw new Error(`路径变量格式化参数 "${variable[1]}" 含有非法字符`);
-                        }
-                    }
-                    return match[1]
-                });
-                for (let index = 0; index < variables.length; index++) {
-                    const variable = variables[index];
-                    segment = segment.replaceAll(variable, '')
+            for (const segment of ast.segments) {
+                Path.checkSegmentChars(segment);
+            }
+        } else if (ast.type === 'Unix') {
+            // Unix 路径不进行非法字符检测，仅检查空字符
+            Path.checkNullChars(ast);
+        } else {
+            // 相对路径：非法字符 + 空字符
+            for (const segment of ast.segments) {
+                Path.checkSegmentChars(segment);
+            }
+            Path.checkNullChars(ast);
+        }
+    }
+
+    /**
+     * 检查单个段内的字面文本与变量格式参数是否含非法字符
+     * @param segment 路径段节点
+     * @throws 如果含非法字符
+     */
+    private static checkSegmentChars(segment: PathSegment): void {
+        const invalidChars = /[<>:"|?*]/;
+        for (const part of segment.parts) {
+            if (part.kind === 'literal') {
+                if (invalidChars.test(part.value)) {
+                    throw new Error(`路径段 "${Path.renderSegment(segment)}" 含有非法字符`);
                 }
-                if (invalidChars.test(segment)) {
-                    throw new Error(`路径段 "${segments[i]}" 含有非法字符`);
-                }
-            }
-        } else if (type === 'Unix') {
-            if (path.indexOf('\0') !== -1) {
-                throw new Error("路径中包含非法空字符");
-            }
-            // Unix路径不进行非法字符检测
-        } else if (type === 'Relative') {
-            if (path.indexOf('\0') !== -1) {
-                throw new Error("路径中包含非法空字符");
-            }
-            if (invalidChars.test(path)) {
-                throw new Error("路径含有非法字符");
+            } else if (part.format !== null && invalidChars.test(part.format)) {
+                throw new Error(`路径变量格式化参数 "${part.format}" 含有非法字符`);
             }
         }
     }
 
     /**
-     * 规范化路径
-     * @param path 原始路径
-     * @param type 路径类型
-     * @returns 规范化后的路径
-     * 
-     * 统一分隔符、合并重复分隔符、处理末尾斜杠，并解析路径中的 "." 和 ".." 导航，绝对路径越界直接抛错。
+     * 检查路径中是否含空字符
+     * @param ast 路径语法树
+     * @throws 如果含空字符
      */
-    private normalizePath(path: string, type: 'Windows' | 'Unix' | 'Relative'): string {
-        const sep = type === 'Windows' ? '\\' : '/';
-
-        if (type === 'Windows') {
-            // 统一为反斜杠
-            path = path.replace(/\//g, '\\');
-            path = path.replace(/\\+/g, '\\');
-        } else {
-            // 对于Unix及相对路径，将反斜杠替换为正斜杠，然后合并重复的斜杠
-            path = path.replace(/\\/g, '/');
-            path = path.replace(/\/+/g, '/');
-        }
-
-        // 拆分路径为段
-        let segments: string[];
-        if (type === 'Windows') {
-            segments = path.split('\\');
-        } else {
-            segments = path.split('/');
-        }
-
-        let isAbsolute = false;
-        let prefix = '';
-        if (type === 'Windows') {
-            // Windows绝对路径的第一段应为驱动器标识，如 "C:"
-            if (/^[A-Za-z]:$/.test(segments[0])) {
-                isAbsolute = true;
-                prefix = segments[0];
-                segments = segments.slice(1);
-            }
-        } else if (type === 'Unix') {
-            if (path.startsWith('/')) {
-                isAbsolute = true;
-                // 去除第一空段（由于首字符为 "/"）
-                if (segments[0] === '') {
-                    segments = segments.slice(1);
+    private static checkNullChars(ast: PathAST): void {
+        for (const segment of ast.segments) {
+            for (const part of segment.parts) {
+                if (part.kind === 'literal' && part.value.indexOf('\0') !== -1) {
+                    throw new Error("路径中包含非法空字符");
                 }
             }
-        } else {
-            isAbsolute = false;
         }
-
-        // 处理相对导航：解析 "." 与 ".."
-        const resolvedSegments = this.resolveSegments(segments, isAbsolute);
-
-        let normalized = '';
-        if (type === 'Windows') {
-            normalized = prefix ? (prefix + sep + resolvedSegments.join(sep)) : resolvedSegments.join(sep);
-            // 保证驱动器路径不为空（如 "C:\"）
-            if (prefix && normalized === prefix) {
-                normalized += sep;
-            }
-        } else if (type === 'Unix') {
-            normalized = (isAbsolute ? sep : '') + resolvedSegments.join(sep);
-            if (isAbsolute && normalized === '') {
-                normalized = sep;
-            }
-        } else {
-            normalized = resolvedSegments.join(sep);
-        }
-        return normalized;
     }
 
     /**
-     * 解析路径段，处理"."和".."导航
-     * @param segments 路径段数组
-     * @param isAbsolute 是否为绝对路径
-     * @returns 处理后的路径段数组
-     * @throws 如果是绝对路径且导航越界
-     * 
-     * 解析路径段，处理 "." 与 ".." 导航，对于绝对路径，如果 ".." 导致越界则抛错
+     * 规范化：解析 "." 与 ".." 导航
+     * 绝对路径导航越界直接抛错，相对路径保留多余的 ".."
+     * @param ast 原始语法树
+     * @returns 规范化后的语法树
      */
-    private resolveSegments(segments: string[], isAbsolute: boolean): string[] {
-        const stack: string[] = [];
-        for (const segment of segments) {
-            if (segment === '' || segment === '.') continue;
-            if (segment === '..') {
-                if (stack.length > 0 && stack[stack.length - 1] !== '..') {
+    private static normalize(ast: PathAST): PathAST {
+        const isAbsolute = ast.type !== 'Relative';
+        const stack: PathSegment[] = [];
+        for (const segment of ast.segments) {
+            if (segment.kind === 'dot') continue;
+            if (segment.kind === 'dotdot') {
+                const top = stack[stack.length - 1];
+                if (top && top.kind !== 'dotdot') {
                     stack.pop();
+                } else if (isAbsolute) {
+                    throw new Error("绝对路径不能越界");
                 } else {
-                    if (isAbsolute) {
-                        throw new Error("绝对路径不能越界");
-                    } else {
-                        // 对于相对路径，保留多余的 ".."
-                        stack.push('..');
-                    }
+                    // 相对路径保留多余的 ".."
+                    stack.push(segment);
                 }
             } else {
                 stack.push(segment);
             }
         }
-        return stack;
+        return { type: ast.type, root: ast.root, segments: stack };
+    }
+
+    /**
+     * 解释执行：将 AST 序列化为规范化的路径字符串
+     * 变量节点还原为 %#name#% / %#name:format#% 形式
+     * @param ast 路径语法树
+     * @returns 规范化路径字符串
+     */
+    private static render(ast: PathAST): string {
+        const sep = ast.type === 'Windows' ? '\\' : '/';
+        const body = ast.segments.map(Path.renderSegment).join(sep);
+        if (ast.type === 'Windows') {
+            return ast.root ? ast.root + sep + body : body;
+        }
+        if (ast.type === 'Unix') {
+            return '/' + body;
+        }
+        return body;
+    }
+
+    /**
+     * 渲染单个段节点为文本
+     * @param segment 路径段节点
+     * @returns 段文本
+     */
+    private static renderSegment(segment: PathSegment): string {
+        let text = '';
+        for (const part of segment.parts) {
+            if (part.kind === 'literal') {
+                text += part.value;
+            } else {
+                text += `${VARIABLE_PREFIX}${part.name}${part.format !== null ? ':' + part.format : ''}${VARIABLE_SUFFIX}`;
+            }
+        }
+        return text;
     }
 
     /**
      * 提取目录部分
-     * @param path 完整路径
-     * @param type 路径类型
+     * 等价于「规范化字符串中最后一个分隔符之前的内容」：
+     * - 纯根路径：Windows "C:\\"、Unix "/"、相对 ""
+     * - 根下仅一个段：目录即根本身（Windows 为盘符 "C:"，Unix 为 ""）
+     * - 多个段：根 + 除末段外的所有段
+     * @param ast 规范化后的语法树
      * @returns 目录部分字符串
-     * 
-     * 返回最后一个分隔符之前的内容
      */
-    private extractDirectory(path: string, type: 'Windows' | 'Unix' | 'Relative'): string {
-        const sep = type === 'Windows' ? '\\' : '/';
-
-        // 特殊处理根目录
-        if (type === 'Windows' && /^[A-Za-z]:\\$/.test(path)) {
-            return path;
+    private static extractDirectory(ast: PathAST): string {
+        const sep = ast.type === 'Windows' ? '\\' : '/';
+        const count = ast.segments.length;
+        if (count === 0) {
+            // 纯根路径
+            if (ast.type === 'Windows') return (ast.root ?? '') + sep;
+            if (ast.type === 'Unix') return '/';
+            return '';
         }
-        if (type === 'Unix' && path === '/') {
-            return path;
+        if (count === 1) {
+            // 根下仅一个段：目录为根本身（Windows 为盘符 "C:"，Unix/相对为 ""）
+            if (ast.type === 'Windows') return ast.root ?? '';
+            return '';
         }
-
-        const lastIndex = path.lastIndexOf(sep);
-        return lastIndex === -1 ? '' : path.substring(0, lastIndex);
+        const body = ast.segments.slice(0, -1).map(Path.renderSegment).join(sep);
+        if (ast.type === 'Windows') return (ast.root ?? '') + sep + body;
+        if (ast.type === 'Unix') return '/' + body;
+        return body;
     }
 
     /**
-     * 提取文件名部分
-     * @param path 完整路径
-     * @param type 路径类型
+     * 提取文件名部分：最后一个段
+     * 无段（纯根路径）返回 ""
+     * @param ast 规范化后的语法树
      * @returns 文件名部分字符串
-     * 
-     * 返回最后一个分隔符之后的内容
      */
-    private extractFileName(path: string, type: 'Windows' | 'Unix' | 'Relative'): string {
-        const sep = type === 'Windows' ? '\\' : '/';
-        const lastIndex = path.lastIndexOf(sep);
-        return lastIndex === -1 ? path : path.substring(lastIndex + 1);
+    private static extractFileName(ast: PathAST): string {
+        const last = ast.segments[ast.segments.length - 1];
+        return last ? Path.renderSegment(last) : '';
     }
 
     /**
@@ -277,14 +401,65 @@ export class Path implements LocalPath {
      * 
      * 从文件名中分离基础名称和拓展名
      */
-    private extractBaseAndExtension(fileName: string): { baseName: string; extension: string } {
+    private static extractBaseAndExtension(fileName: string): { baseName: string; extension: string } {
         const lastDot = fileName.lastIndexOf('.');
         if (lastDot <= 0) {
             return { baseName: fileName, extension: '' };
         }
-        const baseName = fileName.substring(0, lastDot);
-        const extension = fileName.substring(lastDot + 1);
-        return { baseName, extension };
+        return {
+            baseName: fileName.substring(0, lastDot),
+            extension: fileName.substring(lastDot + 1),
+        };
+    }
+
+    /**
+     * 解析路径中的变量并返回渲染结果
+     * 基于规范化 AST 逐变量节点替换，取值语义参考 replaceVariable：
+     * - 值含 format 方法且提供了非空格式参数 → stringify(value.format(format))
+     * - 值为 Date → value.format('YYYY-MM-DD')
+     * - 其余 → stringify(value)
+     * - 未提供的变量保持 %#name#% 原样
+     * @param replacements 变量名 → 值 的替换表
+     * @returns 替换变量后的规范化路径字符串
+     * @remarks 替换值本身若包含其他占位符（如值为 "%#ID#%"），委托 replaceVariable 完成剩余循环解析（含循环检测）
+     */
+    public resolve(replacements: Record<string, unknown>): string {
+        const sep = this.type === 'Windows' ? '\\' : '/';
+        const body = this.normalized.segments
+            .map((segment) => segment.parts
+                .map((part) => part.kind === 'literal'
+                    ? part.value
+                    : Path.resolveValue(part.name, part.format, replacements))
+                .join(''))
+            .join(sep);
+        const rendered = this.type === 'Windows'
+            ? (this.normalized.root ?? '') + sep + body
+            : this.type === 'Unix' ? '/' + body : body;
+        // 替换值可能引入新的占位符：委托 replaceVariable 完成剩余循环解析
+        return rendered.replaceVariable(replacements);
+    }
+
+    /**
+     * 解析单个变量节点为字符串（取值语义参考 replaceVariable）
+     * @param name 变量名
+     * @param format 格式参数（可能为 null）
+     * @param replacements 替换表
+     * @returns 替换后的字符串；变量未提供时保持 %#name#% 原样
+     */
+    private static resolveValue(
+        name: string,
+        format: string | null,
+        replacements: Record<string, unknown>
+    ): string {
+        const value = replacements[name];
+        if (isNullOrUndefined(value)) {
+            // 未提供该变量：保持占位符原样
+            return `${VARIABLE_PREFIX}${name}${format !== null ? ':' + format : ''}${VARIABLE_SUFFIX}`;
+        }
+        if (format !== null && !format.isEmpty() && hasFunction(value, 'format')) {
+            return stringify(value.format(format));
+        }
+        return stringify(value instanceof Date ? value.format('YYYY-MM-DD') : value);
     }
 }
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -101,7 +101,7 @@ export class Config {
                 if (property === 'language') {
                     return Config.getLanguage(value)
                 }
-                log.debug(`get: ${property} ${/password/i.test(property) || /token/i.test(property) || /authorization/i.test(property) ? '凭证已隐藏' : stringify(value)}`)
+                // log.debug(`get: ${property} ${/password/i.test(property) || /token/i.test(property) || /authorization/i.test(property) ? '凭证已隐藏' : stringify(value)}`)
                 return value
             },
             set: function (target, property: string, value) {
@@ -110,7 +110,7 @@ export class Config {
                     return true
                 }
                 GM_setValue(property, value)
-                log.debug(`set: ${property} ${/password/i.test(property) || /token/i.test(property) || /authorization/i.test(property) ? '凭证已隐藏' : stringify(value)}`)
+                // log.debug(`set: ${property} ${/password/i.test(property) || /token/i.test(property) || /authorization/i.test(property) ? '凭证已隐藏' : stringify(value)}`)
                 if (!isNullOrUndefined(target.configChange)) target.configChange(property)
                 return true
             }

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -1,0 +1,22 @@
+/**
+ * 全局常量：GM 存储键 / localStorage 键等（跨模块共享，单一来源）。
+ * 新增存储键时在此声明，避免各模块字符串字面量重复、改键名时遗漏。
+ */
+
+// ── GM 存储键 ──
+/** 调试开关 */
+export const GM_KEY_IS_DEBUG = 'isDebug'
+/** 首次安装标记（true 时走首次引导） */
+export const GM_KEY_IS_FIRST_RUN = 'isFirstRun'
+/** 已安装脚本版本号（升级迁移依据） */
+export const GM_KEY_VERSION = 'version'
+/** 页面选中视频列表（GMSyncDictionary 键名） */
+export const GM_KEY_SELECT_LIST = 'selectList'
+
+// ── localStorage 键 ──
+/** Iwara 登录令牌（refresh_token） */
+export const LS_KEY_TOKEN = 'token'
+/** 缓存的 access token */
+export const LS_KEY_ACCESS_TOKEN = 'accessToken'
+/** 内容分级偏好 */
+export const LS_KEY_RATING = 'rating'

--- a/src/core/db.ts
+++ b/src/core/db.ts
@@ -2,11 +2,12 @@ import "./env";
 import { isNullOrUndefined } from "./env"
 import { openDB, deleteDB, DBSchema, IDBPDatabase } from 'idb';
 import { createLogger } from "./log";
+import { DB_NAME, DB_VERSION, upgradeDatabase } from "./dbMigration";
 
 const log = createLogger('db');
 
 // 数据库模式定义
-interface IwaraDownloadToolDB extends DBSchema {
+export interface IwaraDownloadToolDB extends DBSchema {
     follows: {
         key: string;
         value: Iwara.User;
@@ -84,54 +85,9 @@ export class Database {
     private dbPromise: Promise<IDBPDatabase<IwaraDownloadToolDB>>;
 
     private constructor() {
-        this.dbPromise = openDB<IwaraDownloadToolDB>('IwaraDownloadTool', 22, {
-            upgrade(db, oldVersion, newVersion, transaction) {
-                if (!db.objectStoreNames.contains('follows')) {
-                    const followsStore = db.createObjectStore('follows', { keyPath: 'id' });
-                    followsStore.createIndex('id', 'id', { unique: true });
-                    followsStore.createIndex('username', 'username', { unique: true });
-                    followsStore.createIndex('name', 'name');
-                    followsStore.createIndex('friend', 'friend');
-                    followsStore.createIndex('following', 'following');
-                    followsStore.createIndex('followedBy', 'followedBy');
-                }
-
-                // 检查并创建 friends 表（如果不存在）
-                if (!db.objectStoreNames.contains('friends')) {
-                    const friendsStore = db.createObjectStore('friends', { keyPath: 'id' });
-                    friendsStore.createIndex('id', 'id', { unique: true });
-                    friendsStore.createIndex('username', 'username', { unique: true });
-                    friendsStore.createIndex('name', 'name');
-                    friendsStore.createIndex('friend', 'friend');
-                    friendsStore.createIndex('following', 'following');
-                    friendsStore.createIndex('followedBy', 'followedBy');
-                }
-
-                // 检查并创建 videos 表（如果不存在）
-                if (!db.objectStoreNames.contains('videos')) {
-                    const videosStore = db.createObjectStore('videos', { keyPath: 'ID' });
-                    videosStore.createIndex('ID', 'ID', { unique: true });
-                    videosStore.createIndex('UploadTime', 'UploadTime');
-                    videosStore.createIndex('Private', 'Private');
-                    videosStore.createIndex('Unlisted', 'Unlisted');
-                    videosStore.createIndex('Type', 'Type');
-                }
-
-                // 检查并创建 idmap 表（如果不存在）
-                if (!db.objectStoreNames.contains('idmap')) {
-                    const idmapStore = db.createObjectStore('idmap', { keyPath: 'ID' });
-                    idmapStore.createIndex('ID', 'ID', { unique: true });
-                }
-
-                // 删除旧版 caches 表（v20 → v21），缓存数据会重新生成
-                if (oldVersion < 21 && db.objectStoreNames.contains('caches' as any)) {
-                    db.deleteObjectStore('caches' as any);
-                }
-                // 删除旧版 pairs 表（v21 → v22），缓存数据会重新生成
-                if (oldVersion < 22 && db.objectStoreNames.contains('pairs' as any)) {
-                    db.deleteObjectStore('pairs' as any);
-                }
-            }
+        this.dbPromise = openDB<IwaraDownloadToolDB>(DB_NAME, DB_VERSION, {
+            // 数据库 schema 迁移逻辑见 dbMigration.ts
+            upgrade: (db, oldVersion) => upgradeDatabase(db, oldVersion),
         });
     }
 
@@ -679,7 +635,7 @@ export class Database {
     public async delete(): Promise<void> {
         const db = await this.getDB();
         db.close();
-        await deleteDB('IwaraDownloadTool');
+        await deleteDB(DB_NAME);
     }
 }
 

--- a/src/core/dbMigration.ts
+++ b/src/core/dbMigration.ts
@@ -1,0 +1,75 @@
+import type { IDBPDatabase } from 'idb';
+import type { IwaraDownloadToolDB } from './db';
+
+/**
+ * 数据库 schema 当前版本号（与 idb openDB 的 version 参数保持一致，单一来源）。
+ *
+ * schema 版本历史（git 历史）：
+ * - Dexie 时代（迁移到 idb 之前）：声明 `db.version(2)`，但 Dexie 打开 IndexedDB 时会把版本
+ *   ×10（见 dexie-open.ts: `nativeVerToOpen = Math.round(db.verno * 10)`，升级时再 `oldVer / 10`），
+ *   因此浏览器里实际的原生数据库版本是 **20**（2×10）。3~7 仅存在于被注释掉的旧 VideoDatabase 代码中，从未生效
+ * - v20（迁移到 idb）：沿用 Dexie 时代已有的原生版本 20（= Dexie 自动"加 0"的结果），数据无缝保留，stores 同 v2
+ * - v22（加入 MediaCenter）：新增 idmap，删除 caches（v<21）、pairs（v<22）
+ *   注：v21 为过渡版本（pairs 表曾短暂存在于中间构建），pairs 删除逻辑为兜底
+ */
+/** 数据库名称（openDB / deleteDB 共用，单一来源） */
+export const DB_NAME = 'IwaraDownloadTool';
+
+export const DB_VERSION = 22;
+
+/**
+ * IndexedDB schema 迁移：idb 检测到数据库版本变化时调用（openDB 的 upgrade 回调）。
+ * 采用「幂等创建 + 按 oldVersion 定向清理」策略：
+ * - 各表/索引不存在时创建（可从任意旧版本直接升级）
+ * - 按 oldVersion 删除已废弃的缓存表（caches / pairs，删后数据自动重建）
+ * @param db         版本变化事务内的目标数据库
+ * @param oldVersion 升级前的旧版本号
+ */
+export function upgradeDatabase(db: IDBPDatabase<IwaraDownloadToolDB>, oldVersion: number): void {
+    // 检查并创建 follows 表（如果不存在）
+    if (!db.objectStoreNames.contains('follows')) {
+        const followsStore = db.createObjectStore('follows', { keyPath: 'id' });
+        followsStore.createIndex('id', 'id', { unique: true });
+        followsStore.createIndex('username', 'username', { unique: true });
+        followsStore.createIndex('name', 'name');
+        followsStore.createIndex('friend', 'friend');
+        followsStore.createIndex('following', 'following');
+        followsStore.createIndex('followedBy', 'followedBy');
+    }
+
+    // 检查并创建 friends 表（如果不存在）
+    if (!db.objectStoreNames.contains('friends')) {
+        const friendsStore = db.createObjectStore('friends', { keyPath: 'id' });
+        friendsStore.createIndex('id', 'id', { unique: true });
+        friendsStore.createIndex('username', 'username', { unique: true });
+        friendsStore.createIndex('name', 'name');
+        friendsStore.createIndex('friend', 'friend');
+        friendsStore.createIndex('following', 'following');
+        friendsStore.createIndex('followedBy', 'followedBy');
+    }
+
+    // 检查并创建 videos 表（如果不存在）
+    if (!db.objectStoreNames.contains('videos')) {
+        const videosStore = db.createObjectStore('videos', { keyPath: 'ID' });
+        videosStore.createIndex('ID', 'ID', { unique: true });
+        videosStore.createIndex('UploadTime', 'UploadTime');
+        videosStore.createIndex('Private', 'Private');
+        videosStore.createIndex('Unlisted', 'Unlisted');
+        videosStore.createIndex('Type', 'Type');
+    }
+
+    // 检查并创建 idmap 表（如果不存在）
+    if (!db.objectStoreNames.contains('idmap')) {
+        const idmapStore = db.createObjectStore('idmap', { keyPath: 'ID' });
+        idmapStore.createIndex('ID', 'ID', { unique: true });
+    }
+
+    // 删除旧版 caches 表（v20 → v21），缓存数据会重新生成
+    if (oldVersion < 21 && db.objectStoreNames.contains('caches' as any)) {
+        db.deleteObjectStore('caches' as any);
+    }
+    // 删除旧版 pairs 表（v21 → v22），缓存数据会重新生成
+    if (oldVersion < 22 && db.objectStoreNames.contains('pairs' as any)) {
+        db.deleteObjectStore('pairs' as any);
+    }
+}

--- a/src/core/gmLock.ts
+++ b/src/core/gmLock.ts
@@ -11,8 +11,14 @@
  *   续期，非持有者无法覆盖他人租约。
  * - 防未接管：租约（expires）超时后任何页面都能重新抢占；持有者周期性 renew()
  *   心跳续期，页面关闭/崩溃后租约自然过期，其他页面可接管。
+ * - 无延迟等待：acquireWait() 在锁被他人持有时不立即失败，而是挂起等待——
+ *   同时监听 GM 存储事件（释放立即唤醒）与租约到期定时器（过期瞬间重试），
+ *   锁一可用立即抢占，无需轮询、无 TTL 级延迟。
+ * - 内部心跳：acquireWithHeartbeat() 把续期逻辑内聚到锁自身（setInterval 自动
+ *   renew），调用方只需在关键动作前 isHeld() 复核；失去锁时心跳自动停止。
  *
- * 依赖的 GM API：GM_getValue / GM_setValue / GM_listValues / GM_deleteValue。
+ * 依赖的 GM API：GM_getValue / GM_setValue / GM_listValues / GM_deleteValue
+ * （acquireWait 额外使用 GM_addValueChangeListener / GM_removeValueChangeListener）。
  */
 
 /** 锁值结构：存储在 GM 存储中 */
@@ -23,11 +29,39 @@ export interface GMLockValue {
     expires: number;
 }
 
+/**
+ * GMLock 使用场景的通用预制 TTL（毫秒）——按「续期模式」归纳场景共性，而非按具体业务：
+ *
+ * 场景模型（三类）：
+ * 1. 短任务互斥（ShortTask）：单次短操作的锁，持锁到完成、不续期。
+ *    TTL = 单次操作的最坏耗时；崩溃后恢复快，适合高频短互斥。
+ * 2. 批处理迭代（BatchTask）：长任务由多个迭代组成，每个迭代顶部 renew() 续期。
+ *    TTL = 单次迭代的最坏耗时（须大于迭代内最长的 await 链）。
+ * 3. 守护心跳（DaemonTask）：无限期后台常驻任务，固定心跳 renew()（间隔≈TTL/3）。
+ *    TTL 必须大于浏览器后台标签页定时器节流上限（约 60s），
+ *    否则被节流时心跳失联会被误判过期。
+ *
+ * 同一场景的锁直接引用本枚举；新锁找不到匹配场景时再扩展成员。
+ */
+export enum GMLockTTL {
+    /** 短任务互斥：不续期，TTL 覆盖单次操作最坏耗时（如单视频下载推送） */
+    ShortTask = 60_000,
+    /** 批处理迭代：每次迭代顶部续期（如批量解析下载、全局页面遍历） */
+    BatchTask = 60_000,
+    /** 批处理迭代·慢迭代：单次迭代可能超过 60s（如订阅页大页解析、慢网） */
+    BatchTaskSlow = 120_000,
+    /** 守护心跳：心跳≈TTL/3，须大于后台标签页节流上限约 60s（如 aria2 任务管理器） */
+    DaemonTask = 75_000,
+}
+
 export class GMLock {
     /** GM 存储键前缀，便于 GM_listValues 遍历与清理 */
     private static readonly PREFIX = 'GMLock:';
 
     private readonly owner: string;
+
+    /** 各锁名的内部心跳定时器，由 release()/失去锁时清理 */
+    private readonly heartbeats = new Map<string, ReturnType<typeof setInterval>>();
 
     /**
      * @param owner 持有者唯一标识（同一页面实例内应保持一致，如 UUID）
@@ -76,11 +110,101 @@ export class GMLock {
         return !!value && value.owner === this.owner && value.expires > Date.now();
     }
 
-    /** 释放锁（仅当仍由本页持有，避免误删他人锁） */
+    /** 启动内部心跳：每 interval 自动 renew 续期；失去锁时停止心跳并回调 onLost（幂等，重复启动先停旧心跳） */
+    private startHeartbeat(name: string, ttl: number, interval: number, onLost?: (name: string) => void): void {
+        this.stopHeartbeat(name);
+        const timer = setInterval(() => {
+            if (!this.renew(name, ttl)) {
+                this.stopHeartbeat(name);
+                onLost?.(name);
+            }
+        }, interval);
+        this.heartbeats.set(name, timer);
+    }
+
+    /** 停止内部心跳定时器（幂等） */
+    private stopHeartbeat(name: string): void {
+        const timer = this.heartbeats.get(name);
+        if (timer !== undefined) {
+            clearInterval(timer);
+            this.heartbeats.delete(name);
+        }
+    }
+
+    /**
+     * 抢占锁并启动内部心跳：每 interval 自动 renew 续期，直到 release() 或失去锁。
+     * 续期逻辑从调用方循环内聚到锁自身——调用方只需在关键动作前用 isHeld() 复核，
+     * 失去锁（租约被夺/过期）时心跳自动停止并回调 onLost（可选）。
+     * @param name     锁名
+     * @param ttl      租约时长（毫秒）
+     * @param interval 心跳间隔（毫秒），默认 TTL/3；须保证节流环境下 interval < TTL
+     * @param onLost   失去锁时回调（此时心跳已自动停止）
+     */
+    acquireWithHeartbeat(name: string, ttl: number, interval: number = ttl / 3, onLost?: (name: string) => void): boolean {
+        if (!this.acquire(name, ttl)) return false;
+        this.startHeartbeat(name, ttl, interval, onLost);
+        return true;
+    }
+
+    /**
+     * 等待获取锁并在接管后启动内部心跳（acquireWait + acquireWithHeartbeat 的组合）。
+     * @see acquireWithHeartbeat
+     */
+    async acquireWaitWithHeartbeat(name: string, ttl: number, interval: number = ttl / 3, onLost?: (name: string) => void, timeout: number = Infinity): Promise<boolean> {
+        if (!await this.acquireWait(name, ttl, timeout)) return false;
+        this.startHeartbeat(name, ttl, interval, onLost);
+        return true;
+    }
+
+    /** 释放锁（仅当仍由本页持有，避免误删他人锁）；同时停止内部心跳 */
     release(name: string): void {
+        this.stopHeartbeat(name);
         const key = GMLock.key(name);
         if (GM_getValue<GMLockValue | undefined>(key)?.owner === this.owner) {
             GM_deleteValue(key);
+        }
+    }
+
+    /**
+     * 等待获取锁（无延迟接管）：锁被其他页面持有时不立即失败，而是挂起等待，
+     * 锁一旦可用（持有者释放 / 租约过期）立即抢占并返回 true。
+     *
+     * 无延迟的关键：不依赖轮询——同时监听
+     * 1. GM 存储事件（持有者 release / 其他页面的写入会立即触发本页监听器）；
+     * 2. 租约到期定时器（过期接管不产生 GM 事件，到期瞬间重试）。
+     * 因此从锁可用到接管只有 GM 存储跨页传播的固有毫秒级延迟。
+     *
+     * 竞争语义与 acquire 一致（最后写入者胜出）：多页面同时等待时，成功返回的
+     * 页面仍需在关键动作前用 renew()/isHeld() 基于存储复核。
+     * @param name    锁名
+     * @param ttl     抢占成功后使用的租约时长（毫秒）
+     * @param timeout 最长等待时间（毫秒），默认 Infinity 无限等待
+     * @returns true 表示已成功抢占；false 表示等待超时
+     */
+    async acquireWait(name: string, ttl: number, timeout: number = Infinity): Promise<boolean> {
+        const deadline = Date.now() + timeout;
+        for (;;) {
+            if (this.acquire(name, ttl)) return true;
+            if (Date.now() >= deadline) return false;
+
+            const key = GMLock.key(name);
+            // 传播延迟下可能读到未过期的旧租约：按剩余租约等待（+5ms 缓冲），
+            // 持有者 release 会触发 GM 事件提前唤醒，无需等满租约
+            const current = GM_getValue<GMLockValue | undefined>(key);
+            const remain = current ? Math.max(0, current.expires - Date.now()) : 0;
+            const waitMs = Math.max(0, Math.min(remain + 5, deadline - Date.now()));
+
+            await new Promise<void>(resolve => {
+                let listenerId: number | undefined;
+                let timer: ReturnType<typeof setTimeout> | undefined;
+                const done = () => {
+                    if (listenerId !== undefined) GM_removeValueChangeListener(listenerId);
+                    if (timer !== undefined) clearTimeout(timer);
+                    resolve();
+                };
+                listenerId = GM_addValueChangeListener(key, () => done());
+                timer = setTimeout(done, waitMs);
+            });
         }
     }
 

--- a/src/core/log.ts
+++ b/src/core/log.ts
@@ -1,4 +1,5 @@
 import { originalConsole } from "./hijack";
+import { GM_KEY_IS_DEBUG } from "./constants";
 
 /**
  * 统一日志模块：所有运行时日志通过 createLogger(tag) 获取带前缀的 logger。
@@ -22,7 +23,7 @@ export interface Logger {
 export function createLogger(tag: string): Logger {
     const prefix = `[${tag}]`;
     return {
-        debug: (...args: any[]) => { GM_getValue('isDebug') && originalConsole.debug(prefix, ...args); },
+        debug: (...args: any[]) => { GM_getValue(GM_KEY_IS_DEBUG) && originalConsole.debug(prefix, ...args); },
         info: (...args: any[]) => { originalConsole.info(prefix, ...args); },
         warn: (...args: any[]) => { originalConsole.warn(prefix, ...args); },
         error: (...args: any[]) => { originalConsole.error(prefix, ...args); },

--- a/src/core/migration.ts
+++ b/src/core/migration.ts
@@ -1,0 +1,81 @@
+import { Version } from "./class";
+import { VersionState } from "./enum";
+import { createLogger } from "./log";
+import { i18nList } from "../i18n";
+import { config } from "./config";
+import { db } from "./db";
+import { GM_KEY_IS_FIRST_RUN, GM_KEY_SELECT_LIST, GM_KEY_VERSION } from "./constants";
+
+const log = createLogger('Migration');
+
+/** 迁移所需的运行时依赖（由调用方注入，避免与 main.ts 循环依赖） */
+export interface MigrationDeps {
+    /** 页面选择列表（数据结构变更时需清空） */
+    selectList: { clear(): void }
+}
+
+export interface Migration {
+    from: string
+    name: string
+    run: (deps: MigrationDeps) => void | Promise<void>
+}
+
+/**
+ * 版本迁移注册表：从旧版本升级到当前版本时，按声明顺序执行。
+ * - `from`：低于该版本需要执行此迁移（取历史上发布过的最高阈值）
+ * - `run`：迁移操作（支持异步，可访问注入的 deps）
+ * 新增迁移只需在数组末尾追加一项，无需改动 main() 主流程。
+ *
+ * 历史阈值演变（git 历史，均为同一语义迁移被更高阈值覆盖）：
+ * - 全量重置类（置 isFirstRun=true → 首次引导清空全部配置）：
+ *   3.1.164 → 3.2.5 → 3.2.143 → 3.2.153 → 3.3.0，最终阈值 3.3.0 覆盖所有更早版本
+ * - selectList 清理类：3.2.76（仅清 selectList），已被 3.3.0 的全量重置覆盖
+ * - 清 selectList + 删库类：3.3.22 → 3.3.31，取最高阈值 3.3.31，
+ *   避免 [3.3.22, 3.3.31) 的存量用户（曾发布过 v3.3.27~v3.3.31）漏迁移
+ */
+export const migrations: ReadonlyArray<Migration> = [
+    // v3.3.0：低于该版本的旧配置结构不兼容，强制走首次安装引导（会清空全部配置）
+    { from: '3.3.0', name: 'reset-to-first-run', run: () => GM_setValue(GM_KEY_IS_FIRST_RUN, true) },
+    // v3.3.31：selectList / 本地数据库结构变更，清空选择列表与数据库（历史上阈值曾为 3.3.22）
+    {
+        from: '3.3.31',
+        name: 'clear-selectlist-and-db',
+        run: async ({ selectList }) => {
+            selectList.clear()
+            GM_deleteValue(GM_KEY_SELECT_LIST)
+            await db.delete()
+        },
+    },
+]
+
+export type MigrationResult = 'none' | 'reload' | 'failed'
+
+/**
+ * 执行所有需要运行的版本迁移。
+ * @param deps 迁移所需的运行时依赖
+ * @returns 'none'   无需迁移（含全新安装）
+ *          'reload' 迁移完成，版本号已更新，需要重载页面
+ *          'failed' 迁移失败，中止启动（版本号未更新，下次启动自动重试）
+ */
+export async function runMigrations(deps: MigrationDeps): Promise<MigrationResult> {
+    // 全新安装没有版本记录，不属于升级，无需迁移（避免误弹「配置不兼容」）
+    const installedVersion = GM_getValue(GM_KEY_VERSION, '')
+    if (installedVersion.isEmpty()) return 'none'
+
+    const installed = new Version(installedVersion)
+    const pending = migrations.filter(({ from }) => installed.compare(new Version(from)) === VersionState.Low)
+    if (pending.length === 0) return 'none'
+
+    alert(i18nList[config.language].configurationIncompatible)
+    for (const { from, name, run } of pending) {
+        try {
+            log.info(`migration: ${name} (installed < ${from})`)
+            await run(deps)
+        } catch (error) {
+            log.error(`migration failed: ${name}`, error)
+            return 'failed'
+        }
+    }
+    GM_setValue(GM_KEY_VERSION, GM_info.script.version)
+    return 'reload'
+}

--- a/src/core/mutex.ts
+++ b/src/core/mutex.ts
@@ -8,7 +8,7 @@ var domain = window.location.hostname
 const isOfficial = site.officialDomains.some(d =>
     domain === d || domain.endsWith('.' + d)
 )
-if (!isOfficial && domain.includes('iwara')) {
+if (!isOfficial && site.phishingKeywords.some(k => domain.includes(k))) {
     // @ts-ignore
     XMLHttpRequest.prototype.open = function () { throw new Error('Blocked') }
     // @ts-ignore

--- a/src/data/site.json
+++ b/src/data/site.json
@@ -9,7 +9,11 @@
         "iwara.tv",
         "iwara.ai"
     ],
+    "phishingKeywords": [
+        "iwara"
+    ],
     "apiEndpoint": "api.iwara.tv",
     "syncStartPage": 6000,
-    "maxFindPages": 64
+    "maxFindPages": 64,
+    "pageLimit": 50
 }

--- a/src/download/aria2TrackManager.ts
+++ b/src/download/aria2TrackManager.ts
@@ -3,7 +3,7 @@ import { GMSyncDictionary } from "../core/class";
 import { DownloadType, ToastType } from "../core/enum";
 import { config } from "../core/config";
 import { db } from "../core/db";
-import { GMLock } from "../core/gmLock";
+import { GMLock, GMLockTTL } from "../core/gmLock";
 import { originalAddEventListener } from "../core/hijack";
 import { createLogger } from "../core/log";
 import { unlimitedFetch } from "../core/extension";
@@ -28,9 +28,6 @@ const mediaLog = createLogger('MediaCenter');
 const ARIA2_TRACK_QUEUE_KEY = 'Aria2TrackQueue';
 /** 管理器全局锁名：跨页面仅此一把锁，持有者负责处理整个队列 */
 const ARIA2_TRACK_MANAGER_LOCK = 'aria2TrackManager';
-/** 管理器租约时长（毫秒）：持有页面关闭/崩溃后其他页面可重新选举接管。
- *  不低于后台标签页定时器节流上限（约 60s）+ 余量，避免被节流时误判过期导致频繁重选 */
-const ARIA2_TRACK_MANAGER_TTL = 75_000;
 /** 管理器选举间隔（毫秒）：非管理器页面周期尝试抢占单把锁 */
 const ARIA2_TRACK_ELECTION_INTERVAL = 4000;
 /** 任务队列扫描间隔（毫秒）：把 aria2 中尚未纳入队列的任务补入队列 */
@@ -215,6 +212,8 @@ async function processAria2TrackTask(task: Aria2TrackTask): Promise<void> {
                             if (!newRes?.result?.isEmpty()) {
                                 currentGid = newRes.result;
                                 updateAria2TrackTaskGid(task.videoId, currentGid);
+                                // 重建 = 新连接：重置豁免计数，慢启动期重新豁免
+                                activePollCount = 0;
                                 log.debug(`${task.videoId} 任务重建成功，新 gid=${currentGid}`);
                                 trackStatusToast(task.videoId, videoInfo.Title, ToastType.Warn, 'aria2TrackRestart');
                             }
@@ -234,6 +233,9 @@ async function processAria2TrackTask(task: Aria2TrackTask): Promise<void> {
                                 const freshActive = await restartAria2Task(currentGid, task.videoId, status);
                                 if (freshActive) {
                                     videoInfo = freshActive;
+                                    // 重启 = 新连接：重置豁免计数，慢启动期重新豁免，
+                                    // 避免刚重启的任务因慢启动速度低被连续误判重启（无限重启循环）
+                                    activePollCount = 0;
                                     trackStatusToast(task.videoId, videoInfo.Title, ToastType.Warn, 'aria2TrackRestartSlow');
                                 }
                             }
@@ -256,6 +258,8 @@ async function processAria2TrackTask(task: Aria2TrackTask): Promise<void> {
                         const freshPaused = await restartAria2Task(currentGid, task.videoId, status);
                         if (freshPaused) {
                             videoInfo = freshPaused;
+                            // 重启 = 新连接：重置豁免计数，慢启动期重新豁免
+                            activePollCount = 0;
                             trackStatusToast(task.videoId, videoInfo.Title, ToastType.Warn, 'aria2TrackRestartPaused');
                         }
                     }
@@ -297,7 +301,8 @@ async function tryBecomeAria2TrackManager(): Promise<void> {
     if (aria2TrackManagerLoopRunning) return;
     aria2TrackManagerLoopRunning = true; // 同步置位，防止并发重复启动管理循环
     try {
-        if (!aria2TrackLock.acquire(ARIA2_TRACK_MANAGER_LOCK, ARIA2_TRACK_MANAGER_TTL)) return;
+        // 接管后由 GMLock 内部心跳自动续期（默认 TTL/3），失去锁时主循环通过 isHeld 退出
+        if (!aria2TrackLock.acquireWithHeartbeat(ARIA2_TRACK_MANAGER_LOCK, GMLockTTL.DaemonTask)) return;
         log.debug('本页成为管理器，接管整个队列');
         await startAria2TrackManagerLoop();
     } finally {
@@ -305,11 +310,11 @@ async function tryBecomeAria2TrackManager(): Promise<void> {
     }
 }
 
-/** 管理器主循环：心跳续期 + 同步队列 worker */
+/** 管理器主循环：同步队列 worker（锁心跳由 GMLock 内部维护，循环仅复核持有状态） */
 async function startAria2TrackManagerLoop(): Promise<void> {
     syncAria2TrackWorkers();
-    while (aria2TrackLock.renew(ARIA2_TRACK_MANAGER_LOCK, ARIA2_TRACK_MANAGER_TTL)) {
-        await delay(ARIA2_TRACK_MANAGER_TTL / 3);
+    while (aria2TrackLock.isHeld(ARIA2_TRACK_MANAGER_LOCK)) {
+        await delay(GMLockTTL.DaemonTask / 3);
         syncAria2TrackWorkers();
     }
     // 失去管理器资格：worker 会在下一轮通过 isHeld() 自行退出

--- a/src/download/downloadQueue.ts
+++ b/src/download/downloadQueue.ts
@@ -1,5 +1,6 @@
 import "../core/env";
-import { delay, isNullOrUndefined, prune, stringify } from "../core/env";
+import { delay, isNullOrUndefined, prune, stringify, UUID } from "../core/env";
+import { GMLock, GMLockTTL } from "../core/gmLock";
 import { i18nList } from "../i18n";
 import { DownloadType, PageType, ToastType } from "../core/enum";
 import { config } from "../core/config";
@@ -19,6 +20,8 @@ import { browserDownload, browserDownloadMetadata, iwaradlDownload, othersDownlo
 import { apiEndpoint, domain, pluginMenu, selectList } from "../main";
 
 export async function addDownloadTask() {
+    // 防连点叠加多个输入弹窗
+    if (unsafeWindow.document.querySelector('#pluginOverlay')) return
     let textArea = renderNode({
         nodeType: "textarea",
         attributes: {
@@ -147,57 +150,130 @@ async function downloadTaskUnique(taskList: Dictionary<VideoInfo>) {
     }
 }
 
+/** 解析下载任务防重入标志（循环内每视频有间隔，连点会并发运行多个解析循环） */
+let analyzeDownloadTaskRunning = false
+/** 批量解析下载跨页互斥锁（selectList 跨页同步，多标签页同时批量下载会重复推送任务） */
+const ANALYZE_DOWNLOAD_LOCK = 'analyzeDownloadTask'
+const analyzeDownloadLock = new GMLock(UUID())
+
 export async function analyzeDownloadTask(taskList: Dictionary<VideoInfo> = selectList) {
-    let size = taskList.size
-    let node = renderNode({
-        nodeType: 'p',
-        childs: `${i18nList[config.language].parsingProgress}[${taskList.size}/${size}]`
-    })
-
-    let parsingProgressToast = newToast(ToastType.Info, {
-        node: node,
-        duration: -1
-    })
-
-    function updateParsingProgress() {
-        node.firstChild!.textContent = `${i18nList[config.language].parsingProgress}[${taskList.size}/${size}]`
+    if (analyzeDownloadTaskRunning) {
+        newToast(ToastType.Warn, {
+            text: `%#taskInProgress#%`,
+            duration: 3000,
+            close: true,
+            onClick() { this.hide() }
+        }).show()
+        return
     }
-
-    parsingProgressToast.show()
-    if (config.experimentalFeatures && config.downloadType === DownloadType.Aria2) {
-        await downloadTaskUnique(taskList)
-        updateParsingProgress()
-    }
-
-    for (let [id, info] of taskList) {
-        await pushDownloadTask(await parseVideoInfo(info))
-        taskList.delete(id)
-        updateParsingProgress()
-        !config.enableUnsafeMode && await delay(3000)
-    }
-
-    parsingProgressToast.hide()
-    newToast(
-        ToastType.Info,
-        {
-            text: `%#allCompleted#%`,
+    // 跨页互斥：选中列表跨页同步，另一页面正在批量下载时等待其完成（无延迟接管，心跳由锁内部维护）
+    if (!analyzeDownloadLock.acquireWithHeartbeat(ANALYZE_DOWNLOAD_LOCK, GMLockTTL.BatchTask)) {
+        let waitingToast = newToast(ToastType.Info, {
+            text: `%#waitingForLock#%`,
             duration: -1,
             close: true,
-            onClick() {
-                this.hide()
-            }
+            onClick() { this.hide() }
+        })
+        waitingToast.show()
+        if (!await analyzeDownloadLock.acquireWaitWithHeartbeat(ANALYZE_DOWNLOAD_LOCK, GMLockTTL.BatchTask)) {
+            waitingToast.hide()
+            return
         }
-    ).show()
+        waitingToast.hide()
+    }
+    analyzeDownloadTaskRunning = true
+    try {
+        let size = taskList.size
+        let node = renderNode({
+            nodeType: 'p',
+            childs: `${i18nList[config.language].parsingProgress}[${taskList.size}/${size}]`
+        })
+
+        let parsingProgressToast = newToast(ToastType.Info, {
+            node: node,
+            duration: -1
+        })
+
+        function updateParsingProgress() {
+            node.firstChild!.textContent = `${i18nList[config.language].parsingProgress}[${taskList.size}/${size}]`
+        }
+
+        parsingProgressToast.show()
+        if (config.experimentalFeatures && config.downloadType === DownloadType.Aria2) {
+            await downloadTaskUnique(taskList)
+            updateParsingProgress()
+        }
+
+        for (let [id, info] of taskList) {
+            // 心跳由 GMLock 内部维护：循环内仅复核持有状态，失去锁立即让位
+            if (!analyzeDownloadLock.isHeld(ANALYZE_DOWNLOAD_LOCK)) {
+                parsingProgressToast.hide()
+                newToast(ToastType.Warn, {
+                    text: `%#taskInProgress#%`,
+                    duration: 3000,
+                    close: true,
+                    onClick() { this.hide() }
+                }).show()
+                return
+            }
+            await pushDownloadTask(await parseVideoInfo(info))
+            taskList.delete(id)
+            updateParsingProgress()
+            !config.enableUnsafeMode && await delay(3000)
+        }
+
+        parsingProgressToast.hide()
+        newToast(
+            ToastType.Info,
+            {
+                text: `%#allCompleted#%`,
+                duration: -1,
+                close: true,
+                onClick() {
+                    this.hide()
+                }
+            }
+        ).show()
+    } finally {
+        analyzeDownloadTaskRunning = false
+        analyzeDownloadLock.release(ANALYZE_DOWNLOAD_LOCK)
+    }
 }
 
-export async function pushDownloadTask(videoInfo: VideoInfo) {
+/** 同一视频 ID 的下载推送进行中集合（单页防重入，连点跳过） */
+const pushingVideoIds = new Set<string>()
+/** 下载推送跨页互斥锁（多标签页同时推送同一视频时仅一个页面执行） */
+const PUSH_LOCK_PREFIX = 'pushDownloadTask:'
+const pushLock = new GMLock(UUID())
+
+/** 推送下载任务（顶层入口，单页 + 跨页同 ID 防重入：进行中再次推送会被跳过） */
+export async function pushDownloadTask(videoInfo: VideoInfo): Promise<void> {
+    if (pushingVideoIds.has(videoInfo.ID)) {
+        log.debug(`Skip duplicate push: ${videoInfo.ID}`)
+        return
+    }
+    const lockName = `${PUSH_LOCK_PREFIX}${videoInfo.ID}`
+    if (!pushLock.acquire(lockName, GMLockTTL.ShortTask)) {
+        log.debug(`Skip duplicate push (another page): ${videoInfo.ID}`)
+        return
+    }
+    pushingVideoIds.add(videoInfo.ID)
+    try {
+        await pushDownloadTaskInner(videoInfo)
+    } finally {
+        pushingVideoIds.delete(videoInfo.ID)
+        pushLock.release(lockName)
+    }
+}
+
+async function pushDownloadTaskInner(videoInfo: VideoInfo) {
     switch (videoInfo.Type) {
         case "partial":
             const partialCache = await db.getVideoById(videoInfo.ID)
             if (!isNullOrUndefined(partialCache) && partialCache.Type !== 'full') await db.putVideo(videoInfo)
         case "cache":
         case "init":
-            return await pushDownloadTask(await parseVideoInfo(videoInfo))
+            return await pushDownloadTaskInner(await parseVideoInfo(videoInfo))
         case "fail":
             const cache = await db.getVideoById(videoInfo.ID)
             newToast(

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -143,6 +143,8 @@
     "following": "Following",
     "downloaded": "Downloaded",
     "parsingProgress": "Parsing Progress: ",
+    "taskInProgress": "Parsing in progress, please wait...",
+    "waitingForLock": "Waiting for another page's task to finish...",
     "manualDownloadTips": "For individual downloads, input the video ID here. For batch downloads, separate video IDs with \"|\". Example: AeGUIRO2D5vQ6F|qQsUMJa19LcK3L",
     "noAvailableVideoSource": "No available video sources",
     "videoSourceNotAvailable": "Video source URL unavailable",

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -143,6 +143,8 @@
     "following": "フォロー中",
     "downloaded": "ダウンロード済み",
     "parsingProgress": "解析進捗: ",
+    "taskInProgress": "解析中です。しばらくお待ちください…",
+    "waitingForLock": "他のページのタスク完了を待っています…",
     "manualDownloadTips": "個別ダウンロードはここに動画IDを直接入力してください。バッチダウンロードは「|」で区切った動画IDを提供してください。例: AeGUIRO2D5vQ6F|qQsUMJa19LcK3L",
     "noAvailableVideoSource": "利用可能な動画ソースがありません",
     "videoSourceNotAvailable": "動画ソースURLが利用できません",

--- a/src/i18n/zh_cn.json
+++ b/src/i18n/zh_cn.json
@@ -144,6 +144,8 @@
     "following": "已关注",
     "downloaded": "已下载",
     "parsingProgress": "解析进度: ",
+    "taskInProgress": "解析任务进行中，请稍候…",
+    "waitingForLock": "正在等待其他页面的任务完成…",
     "manualDownloadTips": "单独下载请直接在此处输入视频ID, 批量下载请提供使用“|”分割的视频ID, 例如: AeGUIRO2D5vQ6F|qQsUMJa19LcK3L",
     "noAvailableVideoSource": "没有可供下载的视频源",
     "videoSourceNotAvailable": "视频源地址不可用",

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,8 +14,10 @@ import { createLogger } from "./core/log";
 import { i18nList } from "./i18n";
 import { config, Config } from "./core/config";
 import { originalAddEventListener, originalNodeAppendChild, originalHistoryPushState, originalElementRemove, originalNodeRemoveChild, originalHistoryReplaceState, originalStorageSetItem, originalStorageRemoveItem, originalStorageClear } from "./core/hijack";
-import { Dictionary, GMSyncDictionary, Version } from "./core/class";
+import { Dictionary, GMSyncDictionary } from "./core/class";
 import { db } from "./core/db";
+import { runMigrations } from "./core/migration";
+import { GM_KEY_IS_DEBUG, GM_KEY_IS_FIRST_RUN, GM_KEY_SELECT_LIST, GM_KEY_VERSION, LS_KEY_RATING, LS_KEY_TOKEN } from "./core/constants";
 import { findElement, renderNode, unlimitedFetch } from "./core/extension";
 import { check } from "./network/envCheck";
 import { getAuth } from "./network/auth";
@@ -24,7 +26,7 @@ import { syncAllVideosPages } from "./network/syncPages";
 import { syncCachedToMediaCenter } from "./network/mediaCenter";
 import { trackExistingAria2Tasks } from "./download/aria2TrackManager";
 import { configEdit, injectCheckbox, menu, uninjectCheckbox, waterMark } from "./ui/ui";
-import { PageType, ToastType, VersionState } from "./core/enum";
+import { PageType, ToastType } from "./core/enum";
 import { getPageTypeFromPath } from "./core/pageType";
 import { createInterceptedFetch } from "./network/fetchInterceptor";
 
@@ -36,6 +38,9 @@ if (!domain) {
     throw "Not target"
 }
 
+/** 自动关注的作者用户名（脚本作者的 Iwara 账号） */
+const AUTHOR_USERNAME = 'dawn'
+
 switch (GM_info.scriptHandler) {
     case 'Via':
     case 'Tampermonkey':
@@ -45,7 +50,7 @@ switch (GM_info.scriptHandler) {
         throw `Not support ${GM_info.scriptHandler}`
 }
 
-if (GM_getValue('isDebug')) {
+if (GM_getValue(GM_KEY_IS_DEBUG)) {
     debugger
     log.debug(stringify(GM_info))
     // @ts-ignore
@@ -67,10 +72,10 @@ if (GM_getValue('isDebug')) {
 unsafeWindow.fetch = createInterceptedFetch();
 
 export var apiEndpoint = site.apiEndpoint
-export var isLoggedIn = () => !(unsafeWindow.localStorage.getItem('token') ?? '').isEmpty()
-export var rating = () => localStorage.getItem('rating') ?? 'all'
+export var isLoggedIn = () => !(unsafeWindow.localStorage.getItem(LS_KEY_TOKEN) ?? '').isEmpty()
+export var rating = () => localStorage.getItem(LS_KEY_RATING) ?? 'all'
 
-export var selectList = new GMSyncDictionary<VideoInfo>('selectList')
+export var selectList = new GMSyncDictionary<VideoInfo>(GM_KEY_SELECT_LIST)
 export var pageSelectButtons = new Dictionary<HTMLInputElement>()
 export var mouseTarget: Element | null = null
 export var pluginMenu = new menu();
@@ -93,7 +98,7 @@ selectList.onSync = () => {
 };
 
 export function getSelectButton(id: string): HTMLInputElement | undefined {
-    return pageSelectButtons.has(id) ? pageSelectButtons.get(id) : unsafeWindow.document.querySelector(`input.selectButton[videoid="${id}"]`) as HTMLInputElement
+    return pageSelectButtons.has(id) ? pageSelectButtons.get(id) : unsafeWindow.document.querySelector(`input.selectButton[videoid="${id}"]`) as HTMLInputElement | undefined
 }
 export function getPageType(): PageType {
     // URL 路由来源：browserHistory 走 pathname；hashHistory 走 hash（#/path 或 #!/path）。
@@ -157,11 +162,11 @@ function hijackHistoryReplaceState() {
 function hijackStorage() {
     unsafeWindow.Storage.prototype.setItem = function (key, value) {
         originalStorageSetItem.call(this, key, value)
-        if (key === 'token') pluginMenu.pageChange()
+        if (key === LS_KEY_TOKEN) pluginMenu.pageChange()
     }
     unsafeWindow.Storage.prototype.removeItem = function (key) {
         originalStorageRemoveItem.call(this, key)
-        if (key === 'token') pluginMenu.pageChange()
+        if (key === LS_KEY_TOKEN) pluginMenu.pageChange()
     }
     unsafeWindow.Storage.prototype.clear = function () {
         originalStorageClear.call(this)
@@ -238,35 +243,32 @@ function firstRun() {
     Config.destroyInstance()
     editConfig = new configEdit(config)
     showGuideOverlay(() => {
-        GM_setValue('isFirstRun', false)
-        GM_setValue('version', GM_info.script.version)
+        GM_setValue(GM_KEY_IS_FIRST_RUN, false)
+        GM_setValue(GM_KEY_VERSION, GM_info.script.version)
         editConfig.inject()
     })
 }
+
 async function main() {
     [rainbowCSS, menuCSS, configCSS, overlayCSS, videoCardCSS, toastCSS].forEach(css => GM_addStyle(css));
-    watermark.inject()
-    if (new Version(GM_getValue('version', '0.0.0')).compare(new Version('3.3.0')) === VersionState.Low) {
-        GM_setValue('isFirstRun', true)
-        alert(i18nList[config.language].configurationIncompatible)
+
+    // 升级迁移：旧版本数据不兼容时执行清理
+    const migration = await runMigrations({ selectList })
+    if (migration === 'failed') return      // 迁移失败：中止启动，版本号未更新，下次启动自动重试
+    if (migration === 'reload') {           // 迁移完成：重载进入正常流程
+        unsafeWindow.location.reload()
+        return
     }
-    if (GM_getValue('isFirstRun', true)) {
+
+    // 首次安装引导（3.3.0 之前的旧版本由迁移置 isFirstRun=true 触发）
+    if (GM_getValue(GM_KEY_IS_FIRST_RUN, true)) {
         firstRun()
         return
     }
-    if (new Version(GM_getValue('version', '0.0.0')).compare(new Version('3.3.22')) === VersionState.Low) {
-        alert(i18nList[config.language].configurationIncompatible)
-        try {
-            selectList.clear()
-            GM_deleteValue('selectList')
-            await db.delete()
-            GM_setValue('version', GM_info.script.version)
-            unsafeWindow.location.reload()
-        } catch (error) {
-            log.error(error)
-        }
-        return
-    }
+
+    GM_setValue(GM_KEY_VERSION, GM_info.script.version)
+    watermark.inject()
+
     config.enableBeautify && GM_addStyle(beautifyCSS)
     config.enableWidescreen && GM_addStyle(widescreenCSS)
     if (!await check()) {
@@ -277,7 +279,7 @@ async function main() {
         editConfig.inject()
         return
     }
-    GM_setValue('version', GM_info.script.version)
+
     hijackAddEventListener()
     if (config.autoInjectCheckbox) hijackNodeAppendChild()
     hijackNodeRemoveChild()
@@ -309,7 +311,7 @@ async function main() {
             method: 'GET',
             headers: await getAuth()
         })).json() as Iwara.LocalUser).user
-        let authorProfile = (await (await unlimitedFetch(`https://${apiEndpoint}/profile/dawn`, {
+        let authorProfile = (await (await unlimitedFetch(`https://${apiEndpoint}/profile/${AUTHOR_USERNAME}`, {
             method: 'GET',
             headers: await getAuth()
         })).json() as Iwara.Profile).user

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,13 +14,13 @@ import { createLogger } from "./core/log";
 import { i18nList } from "./i18n";
 import { config, Config } from "./core/config";
 import { originalAddEventListener, originalNodeAppendChild, originalHistoryPushState, originalElementRemove, originalNodeRemoveChild, originalHistoryReplaceState, originalStorageSetItem, originalStorageRemoveItem, originalStorageClear } from "./core/hijack";
-import { Dictionary, GMSyncDictionary } from "./core/class";
+import { Dictionary, GMSyncDictionary, Version } from "./core/class";
 import { db } from "./core/db";
 import { runMigrations } from "./core/migration";
 import { GM_KEY_IS_DEBUG, GM_KEY_IS_FIRST_RUN, GM_KEY_SELECT_LIST, GM_KEY_VERSION, LS_KEY_RATING, LS_KEY_TOKEN } from "./core/constants";
 import { findElement, renderNode, unlimitedFetch } from "./core/extension";
 import { check } from "./network/envCheck";
-import { getAuth } from "./network/auth";
+import { getAuth, verifyLogin } from "./network/auth";
 import { newToast, toastNode } from "./ui/notify";
 import { syncAllVideosPages } from "./network/syncPages";
 import { syncCachedToMediaCenter } from "./network/mediaCenter";
@@ -38,8 +38,6 @@ if (!domain) {
     throw "Not target"
 }
 
-/** 自动关注的作者用户名（脚本作者的 Iwara 账号） */
-const AUTHOR_USERNAME = 'dawn'
 
 switch (GM_info.scriptHandler) {
     case 'Via':
@@ -72,7 +70,6 @@ if (GM_getValue(GM_KEY_IS_DEBUG)) {
 unsafeWindow.fetch = createInterceptedFetch();
 
 export var apiEndpoint = site.apiEndpoint
-export var isLoggedIn = () => !(unsafeWindow.localStorage.getItem(LS_KEY_TOKEN) ?? '').isEmpty()
 export var rating = () => localStorage.getItem(LS_KEY_RATING) ?? 'all'
 
 export var selectList = new GMSyncDictionary<VideoInfo>(GM_KEY_SELECT_LIST)
@@ -110,7 +107,6 @@ export function pageChange() {
     pluginMenu.pageType = getPageType()
     log.debug(pageSelectButtons)
 }
-
 
 function updateSelected() {
     watermark.selected.textContent = ` ${i18nList[config.language].selected} ${selectList.size} `
@@ -248,7 +244,6 @@ function firstRun() {
         editConfig.inject()
     })
 }
-
 async function main() {
     [rainbowCSS, menuCSS, configCSS, overlayCSS, videoCardCSS, toastCSS].forEach(css => GM_addStyle(css));
 
@@ -306,28 +301,38 @@ async function main() {
         }
     }).observe(unsafeWindow.document.body, { childList: true, subtree: true })
 
-    if (isLoggedIn()) {
-        let localUser = (await (await unlimitedFetch(`https://${apiEndpoint}/user`, {
-            method: 'GET',
-            headers: await getAuth()
-        })).json() as Iwara.LocalUser).user
-        let authorProfile = (await (await unlimitedFetch(`https://${apiEndpoint}/profile/${AUTHOR_USERNAME}`, {
-            method: 'GET',
-            headers: await getAuth()
-        })).json() as Iwara.Profile).user
-        if (localUser.id !== authorProfile.id) {
-            if (!authorProfile.following) {
-                unlimitedFetch(`https://${apiEndpoint}/user/${authorProfile.id}/followers`, {
-                    method: 'POST',
-                    headers: await getAuth()
-                })
+    if (await verifyLogin(true)) {
+        try {
+            let localUserRes = await unlimitedFetch(`https://${apiEndpoint}/user`, {
+                method: 'GET',
+                headers: await getAuth()
+            })
+            let authorProfileRes = await unlimitedFetch(`https://${apiEndpoint}/profile/dawn`, {
+                method: 'GET',
+                headers: await getAuth()
+            })
+            if (!localUserRes.ok || !authorProfileRes.ok) {
+                log.warn('登录态验证请求失败:', localUserRes.status, authorProfileRes.status)
+            } else {
+                let localUser = (await localUserRes.json() as Iwara.LocalUser).user
+                let authorProfile = (await authorProfileRes.json() as Iwara.Profile).user
+                if (localUser.id !== authorProfile.id) {
+                    if (!authorProfile.following) {
+                        unlimitedFetch(`https://${apiEndpoint}/user/${authorProfile.id}/followers`, {
+                            method: 'POST',
+                            headers: await getAuth()
+                        })
+                    }
+                    if (!authorProfile.friend) {
+                        unlimitedFetch(`https://${apiEndpoint}/user/${authorProfile.id}/friends`, {
+                            method: 'POST',
+                            headers: await getAuth()
+                        })
+                    }
+                }
             }
-            if (!authorProfile.friend) {
-                unlimitedFetch(`https://${apiEndpoint}/user/${authorProfile.id}/friends`, {
-                    method: 'POST',
-                    headers: await getAuth()
-                })
-            }
+        } catch (error) {
+            log.warn('验证登录态时出错:', error)
         }
     }
     newToast(

--- a/src/network/auth.ts
+++ b/src/network/auth.ts
@@ -4,10 +4,95 @@ import { config } from "../core/config";
 import { createLogger } from "../core/log";
 import { unlimitedFetch } from "../core/extension";
 import { LS_KEY_ACCESS_TOKEN, LS_KEY_TOKEN } from "../core/constants";
-import { apiEndpoint, isLoggedIn } from "../main";
+import { apiEndpoint } from "../main";
 import { getXVersion } from "./xVersion";
 
 const log = createLogger('Auth');
+
+/**
+ * 判断是否已登录（同步）。
+ * 仅凭 localStorage 中存在非空 token 并不可靠（可能已过期、被吊销或为垃圾值），
+ * 这里进一步校验：
+ * 1. token 必须是可解析的 JWT（解析失败视为未登录）；
+ * 2. payload.type 必须是 refresh_token（Iwara 登录写入的 token 类型）；
+ * 3. 若 payload 携带 exp 且已过期，则视为未登录。
+ * @returns 登录状态
+ */
+export function isLoggedIn(): boolean {
+    const refreshToken = unsafeWindow.localStorage.getItem(LS_KEY_TOKEN)
+    if (isNullOrUndefined(refreshToken) || refreshToken.isEmpty()) return false
+
+    try {
+        const payload = getPlayload(`Bearer ${refreshToken}`)
+        if (payload.type && payload.type !== 'refresh_token') return false
+        if (typeof payload.exp === 'number' && payload.exp * 1000 <= Date.now()) return false
+    } catch {
+        // 非 JWT（异常写入/损坏数据）视为未登录
+        return false
+    }
+    return true
+}
+
+/** 远端登录校验结果缓存时长（毫秒） */
+const LOGIN_VERIFY_TTL = 60 * 1000
+let lastVerifyTime = 0
+let lastVerifyResult = false
+
+/**
+ * 通过 API 远端校验登录态（最彻底保证）。
+ * 同步的 isLoggedIn() 只能证明本地存在未过期的 JWT，无法发现服务端吊销、
+ * 凭据轮换等情况；本函数用 /user 请求实测：
+ * - accessToken 失效时先刷新 token 再重试一次；
+ * - 最终仍失败（401）则清理本地凭据，避免后续请求反复携带失效 token；
+ * - 网络异常时不清理凭据（无法断定失效），按未验证处理。
+ * 结果缓存 60 秒，force=true 时跳过缓存强制校验（如启动时）。
+ * @param force 是否跳过缓存强制重新校验
+ */
+export async function verifyLogin(force = false): Promise<boolean> {
+    const now = Date.now()
+    if (!force && now - lastVerifyTime < LOGIN_VERIFY_TTL) return lastVerifyResult
+
+    const cache = (result: boolean) => {
+        lastVerifyResult = result
+        lastVerifyTime = Date.now()
+    }
+
+    if (!isLoggedIn()) {
+        cache(false)
+        return false
+    }
+
+    let res: Response | undefined
+    try {
+        res = await unlimitedFetch(`https://${apiEndpoint}/user`, {
+            method: 'GET',
+            headers: await getAuth()
+        })
+        if (!res.ok) {
+            // accessToken 可能已过期：刷新后重试一次
+            await refreshToken().catch(() => undefined)
+            res = await unlimitedFetch(`https://${apiEndpoint}/user`, {
+                method: 'GET',
+                headers: await getAuth()
+            })
+        }
+    } catch (error) {
+        // 网络异常：无法断定凭据失效，不清理本地 token，按未验证处理
+        log.warn('Failed to verify login:', error)
+        cache(false)
+        return false
+    }
+
+    if (!res.ok) {
+        // 刷新后仍被拒绝：凭据已彻底失效，清理本地状态
+        log.warn('Login credential rejected by server, clearing local credentials')
+        localStorage.removeItem(LS_KEY_TOKEN)
+        localStorage.removeItem(LS_KEY_ACCESS_TOKEN)
+        config.authorization = ''
+    }
+    cache(res.ok)
+    return res.ok
+}
 
 /**
  * 刷新Iwara.tv的访问令牌

--- a/src/network/auth.ts
+++ b/src/network/auth.ts
@@ -3,6 +3,7 @@ import { isNullOrUndefined, prune } from "../core/env";
 import { config } from "../core/config";
 import { createLogger } from "../core/log";
 import { unlimitedFetch } from "../core/extension";
+import { LS_KEY_ACCESS_TOKEN, LS_KEY_TOKEN } from "../core/constants";
 import { apiEndpoint, isLoggedIn } from "../main";
 import { getXVersion } from "./xVersion";
 
@@ -16,12 +17,12 @@ const log = createLogger('Auth');
 export async function refreshToken(): Promise<string> {
     const { authorization } = config;
     if (!isLoggedIn()) throw new Error(`Refresh token failed: Not logged in`)
-    const refreshToken = localStorage.getItem('token') ?? authorization;
+    const refreshToken = localStorage.getItem(LS_KEY_TOKEN) ?? authorization;
     if (isNullOrUndefined(refreshToken) || refreshToken.isEmpty()) {
         throw new Error(`Refresh token failed: no refresh token`);
     }
 
-    const oldAccessToken = localStorage.getItem('accessToken');
+    const oldAccessToken = localStorage.getItem(LS_KEY_ACCESS_TOKEN);
     try {
         const res = await unlimitedFetch(
             `https://${apiEndpoint}/user/token`,
@@ -43,7 +44,7 @@ export async function refreshToken(): Promise<string> {
         }
 
         if (!oldAccessToken || oldAccessToken !== accessToken) {
-            localStorage.setItem('accessToken', accessToken);
+            localStorage.setItem(LS_KEY_ACCESS_TOKEN, accessToken);
         }
 
         return accessToken;
@@ -70,7 +71,7 @@ export async function getAuth(url?: string): Promise<{ Cooike: string; Authoriza
         'Referer': `${window.location.origin}/`,
         'Accept': 'application/json',
         'Cooike': unsafeWindow.document.cookie,
-        'Authorization': isLoggedIn() ? `Bearer ${localStorage.getItem('accessToken') ?? await refreshToken()}` : undefined,
+        'Authorization': isLoggedIn() ? `Bearer ${localStorage.getItem(LS_KEY_ACCESS_TOKEN) ?? await refreshToken()}` : undefined,
         'X-Version': !isNullOrUndefined(url) && !url.isEmpty() ? await getXVersion(url) : undefined,
         'X-Site': unsafeWindow.location.hostname
     })

--- a/src/network/fetchInterceptor.ts
+++ b/src/network/fetchInterceptor.ts
@@ -2,6 +2,7 @@ import { originalFetch } from "../core/hijack";
 import { createLogger } from "../core/log";
 import { config } from "../core/config";
 import { db } from "../core/db";
+import { LS_KEY_ACCESS_TOKEN, LS_KEY_TOKEN } from "../core/constants";
 import { getAuth, getPlayload } from "./auth";
 import { parseVideoInfo } from "./video";
 import { isNull, isNullOrUndefined, isString, isUndefined } from "../core/env";
@@ -34,7 +35,7 @@ function handleAuthorizationHeader(init?: RequestInit): void {
     const payload = getPlayload(authorization);
     const token = authorization.split(' ').pop();
     if (payload['type'] === 'refresh_token' && !isUndefined(token)) {
-        localStorage.setItem('token', token);
+        localStorage.setItem(LS_KEY_TOKEN, token);
         config.authorization = token;
         log.debug('refresh_token: 凭证已隐藏');
     }
@@ -47,9 +48,9 @@ async function handleUserTokenResponse(response: Response): Promise<void> {
     const cloneResponse = response.clone();
     if (!cloneResponse.ok) return;
     const { accessToken } = await cloneResponse.json();
-    const token = localStorage.getItem('accessToken');
+    const token = localStorage.getItem(LS_KEY_ACCESS_TOKEN);
     if (isNull(token) || token !== accessToken) {
-        localStorage.setItem('accessToken', accessToken);
+        localStorage.setItem(LS_KEY_ACCESS_TOKEN, accessToken);
     }
 }
 

--- a/src/network/syncPages.ts
+++ b/src/network/syncPages.ts
@@ -1,16 +1,21 @@
 import "../core/env";
-import { delay, isNullOrUndefined, stringify } from "../core/env";
+import { delay, isNullOrUndefined, stringify, UUID } from "../core/env";
 import { ToastType } from "../core/enum";
 import { unlimitedFetch, renderNode } from "../core/extension";
 import { createLogger } from "../core/log";
 import { db } from "../core/db";
-import { getAuth, refreshToken } from "./auth";
+import { GMLock, GMLockTTL } from "../core/gmLock";
+import { getAuth, refreshToken, verifyLogin } from "./auth";
 import { newToast, toastNode } from "../ui/notify";
 import { parseVideoInfo } from "./video";
-import { apiEndpoint, isLoggedIn } from "../main";
+import { apiEndpoint } from "../main";
 import site from "../data/site.json";
 
 const log = createLogger('SyncPages');
+
+/** 页面遍历跨页互斥锁（防止多个标签页同时遍历，浪费请求且易触发限流） */
+const SYNC_PAGES_LOCK = 'syncAllVideosPages'
+const syncPagesLock = new GMLock(UUID())
 
 /**
  * 抓取单页视频列表并缓存到 IndexedDB
@@ -80,7 +85,7 @@ async function fetchAndCachePage(page: number): Promise<true | false | 'last'> {
  * 每页请求间隔加入随机 jitter 避免触发限流
  */
 export async function syncAllVideosPages(): Promise<void> {
-    if (!isLoggedIn()) {
+    if (!await verifyLogin()) {
         newToast(ToastType.Warn, {
             node: toastNode(`请先登录 iwara`, '页面遍历'),
             duration: 3000
@@ -88,88 +93,124 @@ export async function syncAllVideosPages(): Promise<void> {
         return;
     }
 
-    // 显示进度
-    const progressNode = renderNode({
-        nodeType: 'p',
-        childs: `正在遍历视频页面...`
-    });
-    const progressToast = newToast(ToastType.Info, {
-        node: progressNode,
-        duration: -1
-    });
-    progressToast.show();
-
-    let succeeded = 0;
-    const failedPages: number[] = [];
-    let page = site.syncStartPage;
-
-    while (true) {
-        try {
-            const result = await fetchAndCachePage(page);
-
-            if (result === 'last') {
-                succeeded++;
-                progressNode.firstChild!.textContent = `正在遍历视频页面... 已是最后一页 (${page})，提前结束`;
-                break;
-            }
-
-            if (result === false) {
-                log.warn(`页面 ${page} 失败`);
-                failedPages.push(page);
-                await delay(5000 + Math.random() * 1000);
-                page++;
-                continue;
-            }
-
-            // true: 成功（含空页）
-            succeeded++;
-            progressNode.firstChild!.textContent = `正在遍历视频页面... 第 ${page} 页 (失败: ${failedPages.length})`;
-
-        } catch (error) {
-            log.warn(`页面 ${page} 异常:`, stringify(error));
-            failedPages.push(page);
-        }
-
-        await delay(500 + Math.random() * 1000);
-        page++;
+    // 防多页面重入：仅允许一个页面执行全局遍历（心跳由 GMLock 内部维护）
+    if (!syncPagesLock.acquireWithHeartbeat(SYNC_PAGES_LOCK, GMLockTTL.BatchTask)) {
+        newToast(ToastType.Warn, {
+            text: `%#taskInProgress#%`,
+            duration: 3000,
+            close: true,
+            onClick() { this.hide() }
+        }).show()
+        return
     }
+    try {
+        // 显示进度
+        const progressNode = renderNode({
+            nodeType: 'p',
+            childs: `正在遍历视频页面...`
+        });
+        const progressToast = newToast(ToastType.Info, {
+            node: progressNode,
+            duration: -1
+        });
+        progressToast.show();
 
-    // ── 重试失败的页面 ──
-    let retryFailed: number[] = [];
-    if (failedPages.length > 0) {
-        progressNode.firstChild!.textContent = `正在重试 ${failedPages.length} 个失败页面...`;
+        let succeeded = 0;
+        const failedPages: number[] = [];
+        let page = site.syncStartPage;
 
-        for (const retryPage of failedPages) {
+        while (true) {
+            // 心跳由 GMLock 内部维护：循环内仅复核持有状态，失去锁立即让位
+            if (!syncPagesLock.isHeld(SYNC_PAGES_LOCK)) {
+                progressToast.hide()
+                newToast(ToastType.Warn, {
+                    text: `%#taskInProgress#%`,
+                    duration: 3000,
+                    close: true,
+                    onClick() { this.hide() }
+                }).show()
+                return
+            }
             try {
-                const result = await fetchAndCachePage(retryPage);
+                const result = await fetchAndCachePage(page);
+
+                if (result === 'last') {
+                    succeeded++;
+                    progressNode.firstChild!.textContent = `正在遍历视频页面... 已是最后一页 (${page})，提前结束`;
+                    break;
+                }
 
                 if (result === false) {
-                    log.warn(`重试页面 ${retryPage} 仍失败`);
-                    retryFailed.push(retryPage);
+                    log.warn(`页面 ${page} 失败`);
+                    failedPages.push(page);
+                    await delay(5000 + Math.random() * 1000);
+                    page++;
                     continue;
                 }
 
+                // true: 成功（含空页）
                 succeeded++;
-                progressNode.firstChild!.textContent = `正在重试失败页面... ${retryPage} 成功 (剩余 ${failedPages.length - retryFailed.length - (failedPages.indexOf(retryPage) + 1 - retryFailed.length)} 个待重试)`;
+                progressNode.firstChild!.textContent = `正在遍历视频页面... 第 ${page} 页 (失败: ${failedPages.length})`;
 
             } catch (error) {
-                log.warn(`重试页面 ${retryPage} 异常:`, stringify(error));
-                retryFailed.push(retryPage);
+                log.warn(`页面 ${page} 异常:`, stringify(error));
+                failedPages.push(page);
             }
 
             await delay(500 + Math.random() * 1000);
+            page++;
         }
-    }
 
-    progressToast.hide();
+        // ── 重试失败的页面 ──
+        let retryFailed: number[] = [];
+        if (failedPages.length > 0) {
+            progressNode.firstChild!.textContent = `正在重试 ${failedPages.length} 个失败页面...`;
 
-    newToast(ToastType.Info, {
-        text: `页面遍历完成！成功: ${succeeded} 页${retryFailed.length > 0 ? `，重试后仍失败: ${retryFailed.length} 页` : '，无失败'}`,
-        close: true,
-        onClick() { this.hide(); }
-    }).show();
+            for (const retryPage of failedPages) {
+                // 心跳由 GMLock 内部维护：循环内仅复核持有状态，失去锁立即让位
+                if (!syncPagesLock.isHeld(SYNC_PAGES_LOCK)) {
+                    progressToast.hide()
+                    newToast(ToastType.Warn, {
+                        text: `%#taskInProgress#%`,
+                        duration: 3000,
+                        close: true,
+                        onClick() { this.hide() }
+                    }).show()
+                    return
+                }
+                try {
+                    const result = await fetchAndCachePage(retryPage);
 
-    if (retryFailed.length > 0) {
-        log.warn(`始终失败的页码: ${retryFailed.join(', ')}`);
+                    if (result === false) {
+                        log.warn(`重试页面 ${retryPage} 仍失败`);
+                        retryFailed.push(retryPage);
+                        continue;
+                    }
+
+                    succeeded++;
+                    progressNode.firstChild!.textContent = `正在重试失败页面... ${retryPage} 成功 (剩余 ${failedPages.length - retryFailed.length - (failedPages.indexOf(retryPage) + 1 - retryFailed.length)} 个待重试)`;
+
+                } catch (error) {
+                    log.warn(`重试页面 ${retryPage} 异常:`, stringify(error));
+                    retryFailed.push(retryPage);
+                }
+
+                await delay(500 + Math.random() * 1000);
+            }
+        }
+
+        progressToast.hide();
+
+        newToast(ToastType.Info, {
+            text: `页面遍历完成！成功: ${succeeded} 页${retryFailed.length > 0 ? `，重试后仍失败: ${retryFailed.length} 页` : '，无失败'}`,
+            close: true,
+            onClick() { this.hide(); }
+        }).show();
+
+        if (retryFailed.length > 0) {
+            log.warn(`始终失败的页码: ${retryFailed.join(', ')}`);
+        }
+    } finally {
+        syncPagesLock.release(SYNC_PAGES_LOCK)
     }
 }

--- a/src/network/syncPages.ts
+++ b/src/network/syncPages.ts
@@ -19,7 +19,7 @@ const log = createLogger('SyncPages');
 async function fetchAndCachePage(page: number): Promise<true | false | 'last'> {
     const auth = await getAuth();
     const response = await unlimitedFetch(
-        `https://${apiEndpoint}/videos?sort=date&page=${page}&limit=50`,
+        `https://${apiEndpoint}/videos?sort=date&page=${page}&limit=${site.pageLimit}`,
         { headers: auth as any },
         {
             retry: true,

--- a/src/network/xVersion.ts
+++ b/src/network/xVersion.ts
@@ -1,5 +1,8 @@
 import "../core/env";
 
+/** X-Version 签名密钥（前端与脚本均用同一密钥与算法，服务端据此校验请求签名） */
+const X_VERSION_SECRET = 'mSvL05GfEmeEmsEYfGCnVpEjYgTJraJN';
+
 /**
  * 生成 Iwara 请求的 X-Version 头值：对 [文件名, expires, 固定密钥] 拼接串做 SHA-1 摘要。
  * 前端与脚本均用同一密钥与算法，服务端据此校验请求签名。
@@ -9,7 +12,7 @@ import "../core/env";
  */
 export async function getXVersion(urlString: string): Promise<string> {
     let url = urlString.toURL()
-    const data = new TextEncoder().encode([url.pathname.split("/").pop(), url.searchParams.get('expires'), 'mSvL05GfEmeEmsEYfGCnVpEjYgTJraJN'].join('_'))
+    const data = new TextEncoder().encode([url.pathname.split("/").pop(), url.searchParams.get('expires'), X_VERSION_SECRET].join('_'))
     const hashBuffer = await crypto.subtle.digest('SHA-1', data)
     return Array.from(new Uint8Array(hashBuffer))
         .map(b => b.toString(16).padStart(2, '0'))

--- a/src/ui/configUi.ts
+++ b/src/ui/configUi.ts
@@ -10,6 +10,8 @@ import { newToast } from "./notify";
  * 导入配置文件到脚本（通过文本框粘贴 JSON 配置）
  */
 export async function importConfig() {
+    // 防连点叠加多个输入弹窗
+    if (unsafeWindow.document.querySelector('#pluginOverlay')) return
     let textArea = renderNode({
         nodeType: "textarea",
         attributes: {

--- a/src/ui/ui.ts
+++ b/src/ui/ui.ts
@@ -1,10 +1,10 @@
 import { Config, config } from "../core/config";
 import { db } from "../core/db";
 import { DownloadType, PageType, ToastType } from "../core/enum";
-import { isNullOrUndefined, delay, stringify } from "../core/env";
+import { isNullOrUndefined, delay, stringify, UUID } from "../core/env";
 import { renderNode, unlimitedFetch } from "../core/extension";
 import { check } from "../network/envCheck";
-import { getAuth, refreshToken } from "../network/auth";
+import { getAuth, isLoggedIn, refreshToken, verifyLogin } from "../network/auth";
 import { newToast, toastNode } from "./notify";
 import { parseVideoInfo } from "../network/video";
 import { addDownloadTask, analyzeDownloadTask, pushDownloadTask } from "../download/downloadQueue";
@@ -12,15 +12,20 @@ import { importConfig } from "./configUi";
 import { syncCachedToMediaCenter } from "../network/mediaCenter";
 import { originalNodeAppendChild, originalAddEventListener } from "../core/hijack";
 import { createLogger } from "../core/log";
+import { GMLock, GMLockTTL } from "../core/gmLock";
 import { GM_KEY_IS_DEBUG, GM_KEY_IS_FIRST_RUN, GM_KEY_VERSION } from "../core/constants";
 import { i18nList, type Language } from "../i18n";
-import { apiEndpoint, editConfig, getPageType, isLoggedIn, pageSelectButtons, rating, selectList } from "../main";
+import { apiEndpoint, editConfig, getPageType, pageSelectButtons, rating, selectList } from "../main";
 import site from "../data/site.json";
 
 const log = createLogger('UI');
 
 /** 一个月的毫秒数（计算值，JSON 只能存字面量无法表达，故保留在 TS） */
 const MONTH_MS = 30 * 24 * 60 * 60 * 1000
+
+/** 订阅页遍历跨页互斥锁（防止多个标签页同时遍历订阅页） */
+const PARSE_UNLISTED_LOCK = 'parseUnlistedAndPrivate'
+const parseUnlistedLock = new GMLock(UUID())
 
 export function uninjectCheckbox(element: Element | Node) {
     if (element instanceof HTMLElement) {
@@ -637,6 +642,8 @@ export class menu {
     interface!: HTMLDivElement;
     interfacePage!: HTMLUListElement;
     isTouchDevice!: boolean;
+    /** 页面遍历（parseUnlistedAndPrivate）防重入标志 */
+    private parseRunning = false
     constructor() {
         let body = new Proxy(this, {
             set: (target, prop, value) => {
@@ -762,60 +769,72 @@ export class menu {
     }
 
     public async parseUnlistedAndPrivate() {
-        if (!isLoggedIn()) return
-        const lastMonthTimestamp = Date.now() - MONTH_MS
-        const thisMonthUnlistedAndPrivateVideos = await db.getFilteredVideos(lastMonthTimestamp, Infinity);
-        let parseUnlistedAndPrivateVideos: VideoInfo[] = []
+        // 防重入：pageChange 频繁触发时避免并发启动多个遍历
+        if (this.parseRunning) return
+        this.parseRunning = true
+        try {
+            // 防多页面重入：其他页面正在遍历时静默让位（心跳由 GMLock 内部维护）
+            if (!parseUnlistedLock.acquireWithHeartbeat(PARSE_UNLISTED_LOCK, GMLockTTL.BatchTaskSlow)) return
+            if (!await verifyLogin()) return
+            const lastMonthTimestamp = Date.now() - MONTH_MS
+            const thisMonthUnlistedAndPrivateVideos = await db.getFilteredVideos(lastMonthTimestamp, Infinity);
+            let parseUnlistedAndPrivateVideos: VideoInfo[] = []
 
-        const MAX_FIND_PAGES = site.maxFindPages;
-        let pageCount = 0;
-        log.debug(`Starting fetch loop. MAX_PAGES=${MAX_FIND_PAGES}`);
+            const MAX_FIND_PAGES = site.maxFindPages;
+            let pageCount = 0;
+            log.debug(`Starting fetch loop. MAX_PAGES=${MAX_FIND_PAGES}`);
 
-        while (pageCount < MAX_FIND_PAGES) {
-            log.debug(`Fetching page ${pageCount}.`);
-            const response = await unlimitedFetch(
-                `https://${apiEndpoint}/videos?subscribed=true&limit=${site.pageLimit}&rating=${rating()}&page=${pageCount}`,
-                { method: 'GET', headers: await getAuth() },
-                {
-                    retry: true,
-                    retryDelay: 1000,
-                    onRetry: async () => { await refreshToken() }
+            while (pageCount < MAX_FIND_PAGES) {
+                // 心跳由 GMLock 内部维护：循环内仅复核持有状态，失去锁立即让位
+                if (!parseUnlistedLock.isHeld(PARSE_UNLISTED_LOCK)) return
+                log.debug(`Fetching page ${pageCount}.`);
+                const response = await unlimitedFetch(
+                    `https://${apiEndpoint}/videos?subscribed=true&limit=${site.pageLimit}&rating=${rating()}&page=${pageCount}`,
+                    { method: 'GET', headers: await getAuth() },
+                    {
+                        retry: true,
+                        retryDelay: 1000,
+                        onRetry: async () => { await refreshToken() }
+                    }
+                );
+                log.debug('Received response, parsing JSON.');
+                const data = (await response.json() as Iwara.IPage).results as Iwara.Video[];
+                log.debug(`Page ${pageCount} returned ${data.length} videos.`);
+                data.forEach(info => info.user.following = true);
+                const videoPromises = data.map(info => parseVideoInfo({
+                    Type: 'cache',
+                    ID: info.id,
+                    RAW: info
+                }));
+                log.debug('Initializing VideoInfo promises.');
+                const videoInfos = await Promise.all(videoPromises);
+                parseUnlistedAndPrivateVideos.push(...videoInfos);
+                let test = videoInfos.filter(i => i.Type === 'partial' && (i.Private || i.Unlisted)).any()
+                log.debug('All VideoInfo objects initialized.');
+                if (test && thisMonthUnlistedAndPrivateVideos.intersect(videoInfos, 'ID').any()) {
+                    log.debug(`Found private video on page ${pageCount}.`);
+                    break;
                 }
-            );
-            log.debug('Received response, parsing JSON.');
-            const data = (await response.json() as Iwara.IPage).results as Iwara.Video[];
-            log.debug(`Page ${pageCount} returned ${data.length} videos.`);
-            data.forEach(info => info.user.following = true);
-            const videoPromises = data.map(info => parseVideoInfo({
-                Type: 'cache',
-                ID: info.id,
-                RAW: info
-            }));
-            log.debug('Initializing VideoInfo promises.');
-            const videoInfos = await Promise.all(videoPromises);
-            parseUnlistedAndPrivateVideos.push(...videoInfos);
-            let test = videoInfos.filter(i => i.Type === 'partial' && (i.Private || i.Unlisted)).any()
-            log.debug('All VideoInfo objects initialized.');
-            if (test && thisMonthUnlistedAndPrivateVideos.intersect(videoInfos, 'ID').any()) {
-                log.debug(`Found private video on page ${pageCount}.`);
-                break;
-            }
-            log.debug(`Latest private video not found on page ${pageCount}, continuing.`);
-            pageCount++;
+                log.debug(`Latest private video not found on page ${pageCount}, continuing.`);
+                pageCount++;
 
-            log.debug(`Incremented page to ${pageCount}, delaying next fetch.`);
-            await delay(100);
-        }
-        log.debug('Fetch loop ended. Start updating the database');
-        const existingVideos = await db.getVideosByIds(parseUnlistedAndPrivateVideos.map(v => v.ID));
-        const toUpdate = parseUnlistedAndPrivateVideos.difference(
-            existingVideos.filter(v => v.Type === 'full'), 'ID')
-        if (toUpdate.any()) {
-            log.debug(`Need to update ${toUpdate.length} pieces of data.`);
-            await db.bulkPutVideos(toUpdate)
-            log.debug(`Update Completed.`);
-        } else {
-            log.debug(`No need to update data.`);
+                log.debug(`Incremented page to ${pageCount}, delaying next fetch.`);
+                await delay(100);
+            }
+            log.debug('Fetch loop ended. Start updating the database');
+            const existingVideos = await db.getVideosByIds(parseUnlistedAndPrivateVideos.map(v => v.ID));
+            const toUpdate = parseUnlistedAndPrivateVideos.difference(
+                existingVideos.filter(v => v.Type === 'full'), 'ID')
+            if (toUpdate.any()) {
+                log.debug(`Need to update ${toUpdate.length} pieces of data.`);
+                await db.bulkPutVideos(toUpdate)
+                log.debug(`Update Completed.`);
+            } else {
+                log.debug(`No need to update data.`);
+            }
+        } finally {
+            parseUnlistedLock.release(PARSE_UNLISTED_LOCK)
+            this.parseRunning = false
         }
     }
 
@@ -900,9 +919,8 @@ export class menu {
 
         let downloadThisButton = this.button('downloadThis', async (name, event) => {
             let ID = unsafeWindow.location.href.toURL().pathname.split('/')[2]
-            await pushDownloadTask(await parseVideoInfo({
-                Type: 'init', ID
-            }))
+            // 直接传 init：由 pushDownloadTask 顶层同 ID 锁防连点重复推送（解析也一并纳入锁内）
+            await pushDownloadTask({ Type: 'init', ID })
         })
 
         switch (this.pageType) {

--- a/src/ui/ui.ts
+++ b/src/ui/ui.ts
@@ -12,6 +12,7 @@ import { importConfig } from "./configUi";
 import { syncCachedToMediaCenter } from "../network/mediaCenter";
 import { originalNodeAppendChild, originalAddEventListener } from "../core/hijack";
 import { createLogger } from "../core/log";
+import { GM_KEY_IS_DEBUG, GM_KEY_IS_FIRST_RUN, GM_KEY_VERSION } from "../core/constants";
 import { i18nList, type Language } from "../i18n";
 import { apiEndpoint, editConfig, getPageType, isLoggedIn, pageSelectButtons, rating, selectList } from "../main";
 import site from "../data/site.json";
@@ -263,7 +264,7 @@ const CONFIG_FIELDS: ConfigField[] = [
     {
         name: 'isDebug', type: 'switch', tabs: ['advanced'], defaultValue: false,
         get: (name, defaultValue) => GM_getValue(name, defaultValue),
-        onSet: (target, e) => { GM_setValue('isDebug', (e.target as HTMLInputElement).checked); unsafeWindow.location.reload() }
+        onSet: (target, e) => { GM_setValue(GM_KEY_IS_DEBUG, (e.target as HTMLInputElement).checked); unsafeWindow.location.reload() }
     },
     // 下载页（下载画质在前，下载位置在后）
     { name: 'downloadPriority', type: 'text', tabs: ['download'], group: 'download', visible: (target) => target.checkPriority },
@@ -339,7 +340,7 @@ export class configEdit {
             },
             events: {
                 click: () => {
-                    GM_setValue('isFirstRun', true)
+                    GM_setValue(GM_KEY_IS_FIRST_RUN, true)
                     unsafeWindow.location.reload()
                 }
             }
@@ -773,7 +774,7 @@ export class menu {
         while (pageCount < MAX_FIND_PAGES) {
             log.debug(`Fetching page ${pageCount}.`);
             const response = await unlimitedFetch(
-                `https://${apiEndpoint}/videos?subscribed=true&limit=50&rating=${rating()}&page=${pageCount}`,
+                `https://${apiEndpoint}/videos?subscribed=true&limit=${site.pageLimit}&rating=${rating()}&page=${pageCount}`,
                 { method: 'GET', headers: await getAuth() },
                 {
                     retry: true,
@@ -968,25 +969,25 @@ export class waterMark {
     })
     debugFlag = renderNode({
         nodeType: 'span',
-        childs: `${GM_getValue('isDebug') ? `${i18nList[config.language].isDebug} ${GM_info.scriptHandler}` : ''}`
+        childs: `${GM_getValue(GM_KEY_IS_DEBUG) ? `${i18nList[config.language].isDebug} ${GM_info.scriptHandler}` : ''}`
     })
     body = renderNode({
         nodeType: 'p',
         className: 'fixed-bottom-right',
         childs: [
-            `%#appName#% ${GM_getValue('version')} `,
+            `%#appName#% ${GM_getValue(GM_KEY_VERSION)} `,
             this.selected,
             this.debugFlag
         ],
         events: {
             click: (e: Event) => {
-                if (GM_getValue('isDebug')) return
+                if (GM_getValue(GM_KEY_IS_DEBUG)) return
                 if (this.debugSwitchCount < DEBUG_SWITCH_THRESHOLD) {
                     this.debugSwitchCount++
                     return
                 } else {
-                    GM_setValue('isDebug', true)
-                    this.debugFlag.textContent = `${GM_getValue('isDebug') ? i18nList[config.language].isDebug : ''}`
+                    GM_setValue(GM_KEY_IS_DEBUG, true)
+                    this.debugFlag.textContent = `${GM_getValue(GM_KEY_IS_DEBUG) ? i18nList[config.language].isDebug : ''}`
                     unsafeWindow.location.reload()
                 }
             }

--- a/test/tests/gm-lock.test.ts
+++ b/test/tests/gm-lock.test.ts
@@ -59,3 +59,235 @@ gmLockTestGroup.add(new Test('pruneExpired 只清理过期锁', 'async', functio
     this.assertEqual(a.isHeld('gm-active'), true); // 活跃锁保留
     a.release('gm-active');
 }));
+
+gmLockTestGroup.add(new Test('acquireWait 在他人释放后立即接管', 'async', async function () {
+    const a = new GMLock('owner-A');
+    const b = new GMLock('owner-B');
+    a.acquire('gm-test-lock-wait', 10000);
+
+    const pending = b.acquireWait('gm-test-lock-wait', 10000);
+    // 模拟另一页面释放锁（remote 事件，newValue=undefined 表示删除）
+    (globalThis as any).__GM_simulateRemoteChange('GMLock:gm-test-lock-wait', undefined);
+    this.assertTrue(await pending, '远程释放后应立即接管');
+    this.assertTrue(b.isHeld('gm-test-lock-wait'));
+    b.release('gm-test-lock-wait');
+}));
+
+gmLockTestGroup.add(new Test('acquireWait 在租约到期后接管', 'async', async function () {
+    const a = new GMLock('owner-A');
+    const b = new GMLock('owner-B');
+    a.acquire('gm-test-lock-wait2', 100); // 短租约，无 release 事件
+
+    this.assertTrue(await b.acquireWait('gm-test-lock-wait2', 10000), '租约到期后应立即接管');
+    b.release('gm-test-lock-wait2');
+}));
+
+gmLockTestGroup.add(new Test('acquireWait 超时返回 false', 'async', async function () {
+    const a = new GMLock('owner-A');
+    const b = new GMLock('owner-B');
+    a.acquire('gm-test-lock-wait3', 10000);
+
+    this.assertFalse(await b.acquireWait('gm-test-lock-wait3', 10000, 100), '超时后应返回 false');
+    a.release('gm-test-lock-wait3');
+}));
+
+// ── 极限工况 ──
+
+gmLockTestGroup.add(new Test('极限: 远程覆盖写入后本地复核让位(最后写入者胜出)', 'async', function () {
+    const a = new GMLock('owner-A');
+    a.acquire('gm-lww', 10000);
+    this.assertTrue(a.isHeld('gm-lww'));
+    // 模拟另一页面同时抢占并覆盖写入(真实场景: 双方都读到空闲, 后写者胜出)
+    (globalThis as any).__GM_simulateRemoteChange('GMLock:gm-lww', { owner: 'owner-B', expires: Date.now() + 10000 });
+    // 本地动作前复核: 发现被覆盖, 立即让位
+    this.assertFalse(a.isHeld('gm-lww'), '被覆盖后 isHeld 应失败');
+    this.assertFalse(a.renew('gm-lww', 10000), '被覆盖后 renew 应失败');
+    const b = new GMLock('owner-B');
+    this.assertTrue(b.isHeld('gm-lww'), '覆盖者复核通过');
+    b.release('gm-lww');
+}));
+
+gmLockTestGroup.add(new Test('极限: TTL=0 立即过期', 'async', function () {
+    const a = new GMLock('owner-A');
+    const b = new GMLock('owner-B');
+    a.acquire('gm-ttl0', 0);
+    this.assertFalse(a.isHeld('gm-ttl0'), 'TTL=0 后应视为未持有');
+    this.assertTrue(b.acquire('gm-ttl0', 10000), '他人应立即可抢占');
+    b.release('gm-ttl0');
+}));
+
+gmLockTestGroup.add(new Test('极限: 本页 acquire 等效续期并延长租约', 'async', async function () {
+    const a = new GMLock('owner-A');
+    a.acquire('gm-reacquire', 5000);
+    const expiresBefore = (globalThis as any).GM_getValue('GMLock:gm-reacquire').expires as number;
+    await new Promise(r => setTimeout(r, 20));
+    this.assertTrue(a.acquire('gm-reacquire', 5000), '本页重复 acquire 应成功(续期)');
+    const expiresAfter = (globalThis as any).GM_getValue('GMLock:gm-reacquire').expires as number;
+    this.assertTrue(expiresAfter > expiresBefore, '续期后租约应延长');
+    a.release('gm-reacquire');
+}));
+
+gmLockTestGroup.add(new Test('极限: 非持有者 renew 失败且不改变原租约', 'async', function () {
+    const a = new GMLock('owner-A');
+    const b = new GMLock('owner-B');
+    a.acquire('gm-renew-invariant', 5000);
+    const before = (globalThis as any).GM_getValue('GMLock:gm-renew-invariant') as { owner: string; expires: number };
+    this.assertFalse(b.renew('gm-renew-invariant', 99999), '非持有者 renew 应失败');
+    const after = (globalThis as any).GM_getValue('GMLock:gm-renew-invariant') as { owner: string; expires: number };
+    this.assertEqual(after.owner, before.owner, '原持有者不变');
+    this.assertEqual(after.expires, before.expires, '原租约不变');
+    a.release('gm-renew-invariant');
+}));
+
+gmLockTestGroup.add(new Test('极限: 重复 release 幂等且不伤及新持有者', 'async', function () {
+    const a = new GMLock('owner-A');
+    const b = new GMLock('owner-B');
+    a.acquire('gm-idempotent-release', 5000);
+    a.release('gm-idempotent-release');
+    a.release('gm-idempotent-release'); // 重复释放无操作、不抛错
+    this.assertFalse(a.isHeld('gm-idempotent-release'));
+    b.acquire('gm-idempotent-release', 5000);
+    a.release('gm-idempotent-release'); // 旧持有者释放不影响新持有者
+    this.assertTrue(b.isHeld('gm-idempotent-release'), '新持有者不受旧持有者 release 影响');
+    b.release('gm-idempotent-release');
+}));
+
+gmLockTestGroup.add(new Test('极限: 不同锁名互不干扰', 'async', function () {
+    const a = new GMLock('owner-A');
+    const b = new GMLock('owner-B');
+    a.acquire('gm-lock-x', 10000);
+    this.assertTrue(b.acquire('gm-lock-y', 10000), '不同锁名应独立获取');
+    this.assertTrue(a.isHeld('gm-lock-x') && b.isHeld('gm-lock-y'), '两把锁同时持有');
+    this.assertFalse(b.acquire('gm-lock-x', 10000), '同名锁仍互斥');
+    a.release('gm-lock-x');
+    b.release('gm-lock-y');
+}));
+
+gmLockTestGroup.add(new Test('极限: acquireWait 多等待者接力, 唯一接管且逐个唤醒', 'async', async function () {
+    const lockName = 'gm-wait-relay';
+    const holder = new GMLock('owner-holder');
+    holder.acquire(lockName, 10000);
+
+    const waiters = [new GMLock('w1'), new GMLock('w2'), new GMLock('w3'), new GMLock('w4'), new GMLock('w5')];
+    const pendings = waiters.map(w => w.acquireWait(lockName, 10000));
+    const resolved = new Array(waiters.length).fill(false);
+
+    for (let round = 0; round < waiters.length; round++) {
+        // 模拟当前持有者释放(跨页 remote 事件)
+        (globalThis as any).__GM_simulateRemoteChange(`GMLock:${lockName}`, undefined);
+        // 每轮恰好一个未接管过的等待者接管(已接管的 promise 已 resolve, 必须排除)
+        const winnerIdx = await Promise.race(
+            pendings.map((p, i) => p.then(() => i)).filter((_, i) => !resolved[i])
+        );
+        this.assertFalse(resolved[winnerIdx], `第 ${round} 轮接管的等待者不应已接管过`);
+        resolved[winnerIdx] = true;
+        this.assertTrue(waiters[winnerIdx].isHeld(lockName), `第 ${round} 轮接管者应持有锁`);
+        // 其余等待者应仍在排队(短时间内不得接管)
+        for (let i = 0; i < waiters.length; i++) {
+            if (resolved[i]) continue;
+            const state = await Promise.race([
+                pendings[i].then(() => 'resolved' as const),
+                new Promise<string>(r => setTimeout(() => r('pending'), 80))
+            ]);
+            this.assertEqual(state, 'pending', `第 ${round} 轮后第 ${i} 个等待者不应同时接管`);
+        }
+    }
+    // 清理: 全部 release(幂等)
+    for (const w of waiters) w.release(lockName);
+}));
+
+gmLockTestGroup.add(new Test('极限: 持有者持续续期时等待者不误抢, 停止后到期接管', 'async', async function () {
+    const lockName = 'gm-wait-renew';
+    const a = new GMLock('owner-A');
+    const b = new GMLock('owner-B');
+    a.acquire(lockName, 200);
+
+    const pending = b.acquireWait(lockName, 10000);
+    // 持有者连续续期 3 次(键值变化会唤醒等待者, 但租约未过期不应抢占)
+    for (let i = 0; i < 3; i++) {
+        await new Promise(r => setTimeout(r, 60));
+        this.assertTrue(a.renew(lockName, 300), `第 ${i} 次续期应成功`);
+        this.assertTrue(a.isHeld(lockName));
+        const state = await Promise.race([
+            pending.then(() => 'resolved' as const),
+            new Promise<string>(r => setTimeout(() => r('pending'), 50))
+        ]);
+        this.assertEqual(state, 'pending', '持有者续期期间等待者不应接管');
+    }
+    // 停止续期, 租约到期后应立即接管
+    this.assertTrue(await pending, '停止续期后等待者应在租约到期时接管');
+    b.release(lockName);
+}));
+
+gmLockTestGroup.add(new Test('极限: acquireWait timeout=0 立即失败', 'async', async function () {
+    const a = new GMLock('owner-A');
+    const b = new GMLock('owner-B');
+    a.acquire('gm-wait-timeout0', 10000);
+    const start = Date.now();
+    this.assertFalse(await b.acquireWait('gm-wait-timeout0', 10000, 0), 'timeout=0 应立即返回 false');
+    this.assertTrue(Date.now() - start < 50, 'timeout=0 不应有实际等待');
+    a.release('gm-wait-timeout0');
+}));
+
+gmLockTestGroup.add(new Test('极限: 本页已持有时 acquireWait 立即返回', 'async', async function () {
+    const a = new GMLock('owner-A');
+    const b = new GMLock('owner-B');
+    a.acquire('gm-wait-held', 10000);
+
+    const pending = b.acquireWait('gm-wait-held', 10000);
+    (globalThis as any).__GM_simulateRemoteChange('GMLock:gm-wait-held', undefined);
+    this.assertTrue(await pending, '接管成功');
+    this.assertTrue(b.isHeld('gm-wait-held'));
+
+    const start = Date.now();
+    this.assertTrue(await b.acquireWait('gm-wait-held', 10000), '本页已持有, 再等待应立即成功');
+    this.assertTrue(Date.now() - start < 50, '本页已持有时不应挂起');
+    b.release('gm-wait-held');
+}));
+
+// ── 内部心跳 ──
+
+gmLockTestGroup.add(new Test('acquireWithHeartbeat 内部心跳自动续期', 'async', async function () {
+    const a = new GMLock('owner-A');
+    a.acquireWithHeartbeat('gm-hb-renew', 100, 20);
+    await new Promise(r => setTimeout(r, 150)); // 约 7 个心跳周期, 无心跳时租约早已过期
+    this.assertTrue(a.isHeld('gm-hb-renew'), '内部心跳应持续续期保持持有');
+    a.release('gm-hb-renew');
+}));
+
+gmLockTestGroup.add(new Test('失去锁后心跳停止并触发 onLost', 'async', async function () {
+    const a = new GMLock('owner-A');
+    let lost = false;
+    a.acquireWithHeartbeat('gm-hb-lost', 100, 20, () => { lost = true; });
+    // 模拟被另一页面覆盖(最后写入者胜出)
+    (globalThis as any).__GM_simulateRemoteChange('GMLock:gm-hb-lost', { owner: 'owner-B', expires: Date.now() + 10000 });
+    await new Promise(r => setTimeout(r, 60)); // 一个心跳周期内应发现失去锁
+    this.assertTrue(lost, '失去锁后应触发 onLost');
+    this.assertFalse(a.isHeld('gm-hb-lost'), '失去锁后不应再持有');
+    const value = (globalThis as any).GM_getValue('GMLock:gm-hb-lost') as { owner: string };
+    this.assertEqual(value.owner, 'owner-B', '心跳停止后不应覆盖新持有者');
+    (globalThis as any).GM_deleteValue('GMLock:gm-hb-lost');
+}));
+
+gmLockTestGroup.add(new Test('release 后心跳停止, 锁不被复活', 'async', async function () {
+    const a = new GMLock('owner-A');
+    a.acquireWithHeartbeat('gm-hb-release', 100, 20);
+    await new Promise(r => setTimeout(r, 40));
+    a.release('gm-hb-release');
+    await new Promise(r => setTimeout(r, 80)); // 心跳若未停止会在此复活锁
+    const b = new GMLock('owner-B');
+    this.assertTrue(b.acquire('gm-hb-release', 10000), 'release 后锁应保持空闲');
+    b.release('gm-hb-release');
+}));
+
+gmLockTestGroup.add(new Test('acquireWaitWithHeartbeat 接管后自动续期', 'async', async function () {
+    const a = new GMLock('owner-A');
+    const b = new GMLock('owner-B');
+    a.acquire('gm-hb-wait', 10000);
+    const pending = b.acquireWaitWithHeartbeat('gm-hb-wait', 100, 20);
+    (globalThis as any).__GM_simulateRemoteChange('GMLock:gm-hb-wait', undefined);
+    this.assertTrue(await pending, '接管成功');
+    await new Promise(r => setTimeout(r, 150));
+    this.assertTrue(b.isHeld('gm-hb-wait'), '接管后内部心跳应持续续期');
+    b.release('gm-hb-wait');
+}));

--- a/test/tests/path.test.ts
+++ b/test/tests/path.test.ts
@@ -365,4 +365,221 @@ pathTestGroup.add(new Test('相对路径 以 .. 开头且包含子目录', 'asyn
     this.assertEqual(p.fullPath, '../../a/b');
 }));
 
+// ============ AST 与变量 ============
+
+pathTestGroup.add(new Test('AST 结构（含变量节点）', 'async', function () {
+    const p = new Path('C:\\%#AUTHOR#%\\%#TITLE#%[%#ID#%].mp4');
+    this.assertEqual(p.ast.type, 'Windows');
+    this.assertEqual(p.ast.root, 'C:');
+    this.assertEqual(p.ast.segments.length, 2);
+    // 段1：纯变量
+    const seg1 = p.ast.segments[0];
+    this.assertEqual(seg1.kind, 'name');
+    this.assertEqual(seg1.parts.length, 1);
+    const part1 = seg1.parts[0];
+    this.assertEqual(part1.kind, 'variable');
+    if (part1.kind === 'variable') {
+        this.assertEqual(part1.name, 'AUTHOR');
+        this.assertEqual(part1.format, null);
+    }
+    // 段2：变量 + 字面混合
+    const parts = p.ast.segments[1].parts;
+    this.assertEqual(parts.length, 4);
+    const title = parts[0];
+    const bracket = parts[1];
+    const id = parts[2];
+    const suffix = parts[3];
+    this.assertEqual(title.kind, 'variable');
+    if (title.kind === 'variable') this.assertEqual(title.name, 'TITLE');
+    this.assertEqual(bracket.kind, 'literal');
+    if (bracket.kind === 'literal') this.assertEqual(bracket.value, '[');
+    this.assertEqual(id.kind, 'variable');
+    if (id.kind === 'variable') this.assertEqual(id.name, 'ID');
+    this.assertEqual(suffix.kind, 'literal');
+    if (suffix.kind === 'literal') this.assertEqual(suffix.value, '].mp4');
+}));
+
+pathTestGroup.add(new Test('AST 变量格式参数', 'async', function () {
+    const p = new Path('C:\\%#NowTime:YYYY-MM-DD#%\\file.txt');
+    const part = p.ast.segments[0].parts[0];
+    this.assertEqual(part.kind, 'variable');
+    if (part.kind === 'variable') {
+        this.assertEqual(part.name, 'NowTime');
+        this.assertEqual(part.format, 'YYYY-MM-DD');
+    }
+}));
+
+pathTestGroup.add(new Test('AST 点导航段语义', 'async', function () {
+    const p = new Path('a/./b/../c');
+    // ast 为规范化前的原始语法树：a / . / b / .. / c
+    this.assertEqual(p.ast.segments.length, 5);
+    const seg0 = p.ast.segments[0];
+    const seg2 = p.ast.segments[2];
+    const seg4 = p.ast.segments[4];
+    this.assertEqual(seg0.kind, 'name');
+    const part0 = seg0.parts[0];
+    if (part0.kind === 'literal') this.assertEqual(part0.value, 'a');
+    this.assertEqual(p.ast.segments[1].kind, 'dot');
+    this.assertEqual(seg2.kind, 'name');
+    const part2 = seg2.parts[0];
+    if (part2.kind === 'literal') this.assertEqual(part2.value, 'b');
+    this.assertEqual(p.ast.segments[3].kind, 'dotdot');
+    this.assertEqual(seg4.kind, 'name');
+    const part4 = seg4.parts[0];
+    if (part4.kind === 'literal') this.assertEqual(part4.value, 'c');
+    // 规范化结果反映在 fullPath
+    this.assertEqual(p.fullPath, 'a/c');
+}));
+
+pathTestGroup.add(new Test('resolve 变量替换', 'async', function () {
+    const p = new Path('C:\\%#AUTHOR#%\\%#TITLE#%[%#ID#%].mp4');
+    const resolved = p.resolve({ AUTHOR: 'dawn', TITLE: '测试视频', ID: 'abc123' });
+    this.assertEqual(resolved, 'C:\\dawn\\测试视频[abc123].mp4');
+}));
+
+pathTestGroup.add(new Test('resolve 未提供变量保持原样', 'async', function () {
+    const p = new Path('C:\\%#AUTHOR#%\\file.txt');
+    this.assertEqual(p.resolve({}), 'C:\\%#AUTHOR#%\\file.txt');
+}));
+
+pathTestGroup.add(new Test('resolve 变量格式参数', 'async', function () {
+    const p = new Path('C:\\%#NowTime:YYYY#%\\file.txt');
+    // 无 format 方法的普通值：忽略格式参数，直接 stringify
+    this.assertEqual(p.resolve({ NowTime: '2026' }), 'C:\\2026\\file.txt');
+}));
+
+pathTestGroup.add(new Test('resolve 值含 format 方法', 'async', function () {
+    const p = new Path('C:\\%#QUALITY:upper#%\\file.txt');
+    // 值含 format 方法且提供了格式参数 → 调用 value.format(format)
+    const value = { format: (f: string) => `fmt(${f})` };
+    this.assertEqual(p.resolve({ QUALITY: value }), 'C:\\fmt(upper)\\file.txt');
+}));
+
+pathTestGroup.add(new Test('resolve 嵌套占位符', 'async', function () {
+    const p = new Path('%#AUTHOR#%');
+    // AUTHOR 的值本身含 %#ID#% 占位符，应继续循环解析
+    this.assertEqual(p.resolve({ AUTHOR: '%#ID#%', ID: 'abc' }), 'abc');
+}));
+
+// ============ 变量与占位符分隔符边缘情况 ============
+
+pathTestGroup.add(new Test('变量：纯变量段', 'async', function () {
+    const p = new Path('%#A#%');
+    this.assertEqual(p.type, 'Relative');
+    this.assertEqual(p.fullPath, '%#A#%');
+    this.assertEqual(p.ast.segments.length, 1);
+    const part = p.ast.segments[0].parts[0];
+    this.assertEqual(part.kind, 'variable');
+    if (part.kind === 'variable') {
+        this.assertEqual(part.name, 'A');
+        this.assertEqual(part.format, null);
+    }
+}));
+
+pathTestGroup.add(new Test('变量：相邻变量无字面间隔', 'async', function () {
+    const p = new Path('C:\\%#A#%%#B#%');
+    this.assertEqual(p.ast.segments[0].parts.length, 2);
+    const a = p.ast.segments[0].parts[0];
+    const b = p.ast.segments[0].parts[1];
+    this.assertEqual(a.kind, 'variable');
+    this.assertEqual(b.kind, 'variable');
+    if (a.kind === 'variable') this.assertEqual(a.name, 'A');
+    if (b.kind === 'variable') this.assertEqual(b.name, 'B');
+}));
+
+pathTestGroup.add(new Test('变量：格式参数按首个冒号切分', 'async', function () {
+    // 词法层面：%#A:B:C#% 中 name=A、format=B:C（首个冒号切分，其余冒号归入格式）
+    const p = new Path('C:\\%#A:B:C#%\\file.txt', false);
+    const part = p.ast.segments[0].parts[0];
+    this.assertEqual(part.kind, 'variable');
+    if (part.kind === 'variable') {
+        this.assertEqual(part.name, 'A');
+        this.assertEqual(part.format, 'B:C');
+    }
+    // 校验层面：格式参数含非法字符（冒号）→ 抛错
+    this.assertThrows(() => new Path('C:\\%#A:B:C#%\\file.txt'));
+}));
+
+pathTestGroup.add(new Test('变量：空格式参数', 'async', function () {
+    const p = new Path('C:\\%#A:#%\\file.txt');
+    const part = p.ast.segments[0].parts[0];
+    this.assertEqual(part.kind, 'variable');
+    if (part.kind === 'variable') {
+        this.assertEqual(part.name, 'A');
+        this.assertEqual(part.format, '');
+    }
+    // 渲染保持原样
+    this.assertEqual(p.fullPath, 'C:\\%#A:#%\\file.txt');
+}));
+
+pathTestGroup.add(new Test('变量：空变量名合法', 'async', function () {
+    // %##% 变量名为空，作为不透明节点不抛错
+    const p = new Path('C:\\%##%\\file.txt');
+    this.assertEqual(p.fullPath, 'C:\\%##%\\file.txt');
+    const part = p.ast.segments[0].parts[0];
+    this.assertEqual(part.kind, 'variable');
+    if (part.kind === 'variable') this.assertEqual(part.name, '');
+}));
+
+pathTestGroup.add(new Test('变量：未闭合占位符视为字面文本', 'async', function () {
+    // 只有前缀 %#、无后缀 #% → 整段作为字面量
+    const p = new Path('C:\\100%#done\\file.txt');
+    this.assertEqual(p.fullPath, 'C:\\100%#done\\file.txt');
+    const part = p.ast.segments[0].parts[0];
+    this.assertEqual(part.kind, 'literal');
+    if (part.kind === 'literal') this.assertEqual(part.value, '100%#done');
+}));
+
+pathTestGroup.add(new Test('变量：只有后缀 #% 视为字面文本', 'async', function () {
+    const p = new Path('C:\\done#%\\file.txt');
+    this.assertEqual(p.fullPath, 'C:\\done#%\\file.txt');
+    const part = p.ast.segments[0].parts[0];
+    this.assertEqual(part.kind, 'literal');
+    if (part.kind === 'literal') this.assertEqual(part.value, 'done#%');
+}));
+
+pathTestGroup.add(new Test('变量：名称可含单个 #（分隔符成对匹配）', 'async', function () {
+    const p = new Path('C:\\%#a#b#%\\file.txt');
+    const part = p.ast.segments[0].parts[0];
+    this.assertEqual(part.kind, 'variable');
+    if (part.kind === 'variable') this.assertEqual(part.name, 'a#b');
+}));
+
+pathTestGroup.add(new Test('变量：不能跨路径分隔符', 'async', function () {
+    // %#A\B#% 中的 \ 是路径分隔符，变量被切断为两个字面段
+    const p = new Path('C:\\%#A\\B#%\\file.txt');
+    this.assertEqual(p.ast.segments.length, 3);
+    const s0 = p.ast.segments[0].parts[0];
+    const s1 = p.ast.segments[1].parts[0];
+    this.assertEqual(s0.kind, 'literal');
+    this.assertEqual(s1.kind, 'literal');
+    if (s0.kind === 'literal') this.assertEqual(s0.value, '%#A');
+    if (s1.kind === 'literal') this.assertEqual(s1.value, 'B#%');
+}));
+
+pathTestGroup.add(new Test('变量：各路径类型均支持', 'async', function () {
+    const win = new Path('C:\\%#A#%\\x');
+    this.assertEqual(win.type, 'Windows');
+    this.assertEqual(win.fullPath, 'C:\\%#A#%\\x');
+    const unix = new Path('/%#A#%/x');
+    this.assertEqual(unix.type, 'Unix');
+    this.assertEqual(unix.fullPath, '/%#A#%/x');
+    const rel = new Path('%#A#%/x');
+    this.assertEqual(rel.type, 'Relative');
+    this.assertEqual(rel.fullPath, '%#A#%/x');
+}));
+
+pathTestGroup.add(new Test('resolve：变量值为空字符串不折叠分隔符', 'async', function () {
+    // 变量段解析为空后保留两侧分隔符，产生空段（C:\ + \file.txt）
+    const p = new Path('C:\\%#A#%\\file.txt');
+    this.assertEqual(p.resolve({ A: '' }), 'C:\\\\file.txt');
+}));
+
+pathTestGroup.add(new Test('resolve：字面 % 与 # 不受影响', 'async', function () {
+    // 未闭合的占位符不是变量，不会被替换
+    const p = new Path('C:\\100%#done\\#tag.txt');
+    this.assertEqual(p.fullPath, 'C:\\100%#done\\#tag.txt');
+    this.assertEqual(p.resolve({ done: 'x' }), 'C:\\100%#done\\#tag.txt');
+}));
+
 export default pathTestGroup;


### PR DESCRIPTION
## 变更内容

### GMLock 跨页面原子锁增强
- 新增 `acquireWait()` 无延迟等待接管(释放事件 + 租约到期双通道唤醒)
- 新增 `acquireWithHeartbeat()` 内部心跳,续期逻辑内聚到锁自身,调用方仅保留 `isHeld()` 复核
- 新增 `GMLockTTL` 场景预制枚举(短任务互斥/批处理迭代/慢迭代/守护心跳)
- 接入 `syncAllVideosPages`、`parseUnlistedAndPrivate`、`analyzeDownloadTask`(含 acquireWait 等待接管)、`pushDownloadTask`(per-video 跨页去重)

### 登录态验证重构
- `isLoggedIn()` 改为 JWT 结构/类型/过期校验,逻辑下沉 `auth.ts`,不再从 `main.ts` 导出
- 新增 `verifyLogin()` 远端校验(与 iwara 官方前端方案对齐:GET /user 实测、401 刷新重试、彻底失效清理凭据、网络异常不清凭据)
- `main()` 启动验证加 `res.ok` 检查与异常保护

### 下载队列防重入
- `analyzeDownloadTask` 单页 + 跨页互斥(selectList 跨页同步,防多页重复推送)
- `pushDownloadTask` 同 ID 单页 Set + 跨页 GMLock 双层防重
- `addDownloadTask`/`importConfig` 弹窗防叠加
- **修复 aria2TrackManager:重启后的任务未获慢启动豁免(无限重启循环),三处重启/重建后显式重置豁免计数**

### 其他
- 配置/日志系统重构(createLogger)、数据库迁移、i18n 新键(taskInProgress/waitingForLock 三语)
- GMLock 测试 23 个(含极限工况:多等待者接力、续期不误抢、内部心跳等),全套件 523 全绿